### PR TITLE
Add additional volume and info methods

### DIFF
--- a/catt/cli.py
+++ b/catt/cli.py
@@ -63,6 +63,21 @@ def volume(level):
     CastController().volume(level)
 
 
+@cli.command(short_help="Turn up volume by an 0.1 increment")
+def volumeup():
+    CastController().volumeup()
+
+
+@cli.command(short_help="Turn down volume by an 0.1 increment")
+def volumedown():
+    CastController().volumedown()
+
+
 @cli.command(short_help="Show some information about the currently-playing video.")
 def status():
     CastController().status()
+
+
+@cli.command(short_help="Show complete information about the currently-playing video")
+def info():
+    CastController().info()

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -97,6 +97,12 @@ class CastController:
     def volume(self, level):
         self.cast.set_volume(level)
 
+    def volumeup(self):
+        self.cast.volume_up()
+
+    def volumedown(self):
+        self.cast.volume_down()
+
     def status(self):
         status = self.cast.media_controller.status.__dict__
         if not status["duration"]:
@@ -113,6 +119,11 @@ class CastController:
             "Remaining minutes: {remaining_minutes:0.1f}\n"
             "State: {player_state}\n".format(**status)
         )
+
+    def info(self):
+        status = self.cast.media_controller.status.__dict__
+        for (key, value) in status.items():
+            echo("%s : %s" % (key, value))
 
     def kill(self):
         self.cast.quit_app()


### PR DESCRIPTION
Howdy. A few further improvements here: "volumeup" and "volumedown" for incremental volume change, useful for keyboard-shortcuts and the like. And "info" for a complete dump of the contents of  cast.media_controller.status, which I think would be useful for testing/debugging purposes.