### PR TITLE
Remove unnecessary code from play_media

### DIFF
--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -66,12 +66,6 @@ class CastController:
         time.sleep(0.2)
 
     def play_media(self, url, content_type="video/mp4"):
-        NON_BLOCKING_APPS = ['Backdrop', 'Default Media Receiver',
-                             'BubbleUPnP']
-        if self.cast.app_display_name not in NON_BLOCKING_APPS:
-            self.kill()
-            while self.cast.app_display_name != 'Backdrop':
-                time.sleep(1)
         self.cast.play_media(url, content_type)
 
     def play(self):


### PR DESCRIPTION
Howdy. A while back I gutted play_media of the checks we are doing now, to see if they were actually making a difference. It turns out they are not. I have had no failure in this period with this gutted version of play_media. I am pretty sure that, as long as we exclusively are using the 'Default Media Receiver' for playback, no blocking could occur.