### PR TITLE
Add config

### DIFF
--- a/catt/cli.py
+++ b/catt/cli.py
@@ -159,7 +159,7 @@ def writeconfig(settings):
     config_dir = click.get_app_dir("catt")
     try:
         os.mkdir(config_dir)
-    except FileExistsError:
+    except:
         pass
     config_filename = os.path.join(config_dir, "catt.json")
     with open(config_filename, "w") as config:
@@ -171,7 +171,7 @@ def readconfig():
     try:
         with open(config_filename, "r") as config:
             return json.load(config)
-    except FileNotFoundError:
+    except:
         return None
 
 

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -35,8 +35,8 @@ def cli(ctx, delete_cache, write_config, device):
     ctx.obj["device"] = device
     if write_config:
         if device:
-            cast = CastController(device)
-            writeconfig()
+            CastController.get_chromecast(device)
+            writeconfig(ctx.obj)
         else:
             raise CattCliError("No device specified.")
 
@@ -154,7 +154,7 @@ def info(settings):
     cast = CastController(settings["device"])
     cast.info()
 
-@click.pass_obj
+
 def writeconfig(settings):
     config_dir = click.get_app_dir("catt")
     try:

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -25,7 +25,7 @@ class CattCliError(click.ClickException):
 @click.option("--delete-cache", is_flag=True,
               help="Empty the Chromecast discovery cache.")
 @click.option("--write-config", is_flag=True,
-              help="Write name of default Chromecast device to config file")
+              help="Write name of default Chromecast device to config file.")
 @click.option("-d", "--device", metavar="NAME",
               help="Select Chromecast device.")
 @click.pass_context

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     entry_points={
-        'console_scripts': ['catt=catt.cli:cli'],
+        'console_scripts': ['catt=catt.cli:main'],
     },
 )


### PR DESCRIPTION
Howdy. As promised, here's the config.

There's a few things to consider with this PR:
I've had to change my strategy with regards to [this problem](https://github.com/pallets/click/issues/456#issuecomment-159543498), in order to make reading values from config into defaults work. Which also means that I've had to alter `entry_points` in `setup.py`.
Also, I realize that the code in `cli()` is suboptimal, as it is not the proper click-esque way of solving the problem, with raising that exception directly in the code. And I've been unsure as to whether I should pass the device value directly to `writeconfig()` from `cli()`, or to use the `pass_obj` decorator. I've chosen the latter, as for now, we can write ctx.obj to disk, as is.