### PR TITLE
fix: Make catt work with pychromecast 0.8.0

### DIFF
--- a/catt/cli.py
+++ b/catt/cli.py
@@ -88,7 +88,7 @@ def write_config(settings):
 @click.argument("video_url")
 @click.pass_obj
 def cast(settings, video_url):
-    cast = CastController(settings["device"])
+    cast = CastController(settings["device"], state_check=False)
     cc_name = cast.cast.device.friendly_name
 
     if "://" not in video_url:
@@ -134,7 +134,7 @@ def play(settings):
 @cli.command(short_help="Stop playing.")
 @click.pass_obj
 def stop(settings):
-    cast = CastController(settings["device"])
+    cast = CastController(settings["device"], state_check=False)
     cast.kill()
 
 
@@ -168,21 +168,21 @@ def seek(settings, time):
 @click.argument("level", type=click.IntRange(0, 100), metavar="LVL")
 @click.pass_obj
 def volume(settings, level):
-    cast = CastController(settings["device"])
+    cast = CastController(settings["device"], state_check=False)
     cast.volume(level / 100.0)
 
 
 @cli.command(short_help="Turn up volume by an 0.1 increment.")
 @click.pass_obj
 def volumeup(settings):
-    cast = CastController(settings["device"])
+    cast = CastController(settings["device"], state_check=False)
     cast.volumeup()
 
 
 @cli.command(short_help="Turn down volume by an 0.1 increment.")
 @click.pass_obj
 def volumedown(settings):
-    cast = CastController(settings["device"])
+    cast = CastController(settings["device"], state_check=False)
     cast.volumedown()
 
 

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -133,7 +133,6 @@ class Cache:
 
 class CastController:
     def __init__(self, device_name, state_check=True):
-        INACTIVE = ["UNKNOWN", "IDLE"]
         cache = Cache()
         cached_ip = cache.get(device_name)
 
@@ -148,11 +147,14 @@ class CastController:
         self.cast.wait()
 
         if state_check:
-            if self.cast.app_id == "E8C28D3C" or not self.cast.app_id:
-                raise CattCastError("Chromecast is inactive.")
-            self.cast.media_controller.block_until_active(1.0)
-            if self.cast.media_controller.status.player_state in INACTIVE:
-                raise CattCastError("Nothing is currently playing.")
+            self._check_state()
+
+    def _check_state(self):
+        if self.cast.app_id == "E8C28D3C" or not self.cast.app_id:
+            raise CattCastError("Chromecast is inactive.")
+        self.cast.media_controller.block_until_active(1.0)
+        if self.cast.media_controller.status.player_state in ["UNKNOWN", "IDLE"]:
+            raise CattCastError("Nothing is currently playing.")
 
     def play_media(self, url, content_type="video/mp4"):
         self.cast.play_media(url, content_type)
@@ -163,9 +165,6 @@ class CastController:
 
     def pause(self):
         self.cast.media_controller.pause()
-
-    def stop(self):
-        self.cast.media_controller.stop()
 
     def seek(self, seconds):
         self.cast.media_controller.seek(seconds)

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -143,30 +143,45 @@ class CastController:
         except (pychromecast.error.ChromecastConnectionError, ValueError):
             self.cast = get_chromecast(device_name)
             cache.set(self.cast.name, self.cast.host)
-        time.sleep(0.2)
+
+        self.cast.wait()
+
+    def check_state(self):
+        if self.cast.app_id == "E8C28D3C" or not self.cast.app_id:
+            raise CattCastError("Chromecast is inactive.")
+        self.cast.media_controller.block_until_active(1)
+        if self.cast.media_controller.status.player_state in ["UNKNOWN", "IDLE"]:
+            raise CattCastError("Nothing is currently playing.")
 
     def play_media(self, url, content_type="video/mp4"):
         self.cast.play_media(url, content_type)
+        self.cast.media_controller.block_until_active()
 
     def play(self):
+        self.check_state()
         self.cast.media_controller.play()
 
     def pause(self):
+        self.check_state()
         self.cast.media_controller.pause()
 
     def stop(self):
+        self.check_state()
         self.cast.media_controller.stop()
 
     def seek(self, seconds):
-        self.cast.media_controller.seek(int(seconds))
+        self.check_state()
+        self.cast.media_controller.seek(seconds)
 
     def rewind(self, seconds):
+        self.check_state()
         pos = self.cast.media_controller.status.current_time
-        self.seek(pos - seconds)
+        self.cast.media_controller.seek(pos - seconds)
 
     def ffwd(self, seconds):
+        self.check_state()
         pos = self.cast.media_controller.status.current_time
-        self.seek(pos + seconds)
+        self.cast.media_controller.seek(pos + seconds)
 
     def volume(self, level):
         self.cast.set_volume(level)
@@ -178,9 +193,11 @@ class CastController:
         self.cast.volume_down()
 
     def status(self):
+        self.check_state()
         status = self.cast.media_controller.status.__dict__
+
         if not status["duration"]:
-            echo("Nothing currently playing.")
+            echo("State: {player_state}\n".format(**status))
             return
 
         status["current_time"] = int(status["current_time"])
@@ -195,6 +212,7 @@ class CastController:
         )
 
     def info(self):
+        self.check_state()
         status = self.cast.media_controller.status.__dict__
         for (key, value) in status.items():
             echo("%s : %s" % (key, value))

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -149,7 +149,7 @@ class CastController:
     def check_state(self):
         if self.cast.app_id == "E8C28D3C" or not self.cast.app_id:
             raise CattCastError("Chromecast is inactive.")
-        self.cast.media_controller.block_until_active(1)
+        self.cast.media_controller.block_until_active(1.0)
         if self.cast.media_controller.status.player_state in ["UNKNOWN", "IDLE"]:
             raise CattCastError("Nothing is currently playing.")
 

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -146,7 +146,7 @@ class CastController:
 
         self.cast.wait()
 
-    def check_state(self):
+    def _check_state(self):
         if self.cast.app_id == "E8C28D3C" or not self.cast.app_id:
             raise CattCastError("Chromecast is inactive.")
         self.cast.media_controller.block_until_active(1.0)
@@ -158,28 +158,28 @@ class CastController:
         self.cast.media_controller.block_until_active()
 
     def play(self):
-        self.check_state()
+        self._check_state()
         self.cast.media_controller.play()
 
     def pause(self):
-        self.check_state()
+        self._check_state()
         self.cast.media_controller.pause()
 
     def stop(self):
-        self.check_state()
+        self._check_state()
         self.cast.media_controller.stop()
 
     def seek(self, seconds):
-        self.check_state()
+        self._check_state()
         self.cast.media_controller.seek(seconds)
 
     def rewind(self, seconds):
-        self.check_state()
+        self._check_state()
         pos = self.cast.media_controller.status.current_time
         self.cast.media_controller.seek(pos - seconds)
 
     def ffwd(self, seconds):
-        self.check_state()
+        self._check_state()
         pos = self.cast.media_controller.status.current_time
         self.cast.media_controller.seek(pos + seconds)
 
@@ -193,7 +193,7 @@ class CastController:
         self.cast.volume_down()
 
     def status(self):
-        self.check_state()
+        self._check_state()
         status = self.cast.media_controller.status.__dict__
 
         if not status["duration"]:
@@ -212,7 +212,7 @@ class CastController:
         )
 
     def info(self):
-        self.check_state()
+        self._check_state()
         status = self.cast.media_controller.status.__dict__
         for (key, value) in status.items():
             echo("%s : %s" % (key, value))

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open('README.rst') as readme_file:
 
 requirements = [
     "youtube-dl>=2017.3.15",
-    "PyChromecast==0.7.7",
+    "PyChromecast>=0.8.0",
     "Click>=5.0",
 ]
 


### PR DESCRIPTION
Howdy.
So I worked around the issues and made this work almost perfectly (see notes).

With this PR, `catt` will now fail if nothing is playing (except `cast` of course), whereas before, you could do `catt ffwd 50` when nothing was playing, and `catt` would just exit quietly. The failling behaviour could also be useful in scripts.

Fixes #12 
EDIT: ready to merge