### PR TITLE
feat: Add argument to volumeupdown

### DIFF
--- a/catt/cli.py
+++ b/catt/cli.py
@@ -172,7 +172,7 @@ def volume(settings, level):
     cast.volume(level / 100.0)
 
 
-@cli.command(short_help="Turn up volume by an DELTA increment.")
+@cli.command(short_help="Turn up volume by a DELTA increment.")
 @click.argument("delta", type=click.IntRange(1, 100),
                 required=False, default=10, metavar="DELTA")
 @click.pass_obj
@@ -181,7 +181,7 @@ def volumeup(settings, delta):
     cast.volumeup(delta / 100.0)
 
 
-@cli.command(short_help="Turn down volume by an DELTA increment.")
+@cli.command(short_help="Turn down volume by a DELTA increment.")
 @click.argument("delta", type=click.IntRange(1, 100),
                 required=False, default=10, metavar="DELTA")
 @click.pass_obj

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -173,7 +173,7 @@ def volume(settings, level):
 
 
 @cli.command(short_help="Turn up volume by an DELTA increment.")
-@click.argument("delta", type=click.IntRange(0, 100),
+@click.argument("delta", type=click.IntRange(1, 100),
                 required=False, default=10, metavar="DELTA")
 @click.pass_obj
 def volumeup(settings, delta):
@@ -182,7 +182,7 @@ def volumeup(settings, delta):
 
 
 @cli.command(short_help="Turn down volume by an DELTA increment.")
-@click.argument("delta", type=click.IntRange(0, 100),
+@click.argument("delta", type=click.IntRange(1, 100),
                 required=False, default=10, metavar="DELTA")
 @click.pass_obj
 def volumedown(settings, delta):

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -172,18 +172,22 @@ def volume(settings, level):
     cast.volume(level / 100.0)
 
 
-@cli.command(short_help="Turn up volume by an 0.1 increment.")
+@cli.command(short_help="Turn up volume by an DELTA increment.")
+@click.argument("delta", type=click.IntRange(0, 100),
+                required=False, default=10, metavar="DELTA")
 @click.pass_obj
-def volumeup(settings):
+def volumeup(settings, delta):
     cast = CastController(settings["device"], state_check=False)
-    cast.volumeup()
+    cast.volumeup(delta / 100.0)
 
 
-@cli.command(short_help="Turn down volume by an 0.1 increment.")
+@cli.command(short_help="Turn down volume by an DELTA increment.")
+@click.argument("delta", type=click.IntRange(0, 100),
+                required=False, default=10, metavar="DELTA")
 @click.pass_obj
-def volumedown(settings):
+def volumedown(settings, delta):
     cast = CastController(settings["device"], state_check=False)
-    cast.volumedown()
+    cast.volumedown(delta / 100.0)
 
 
 @cli.command(short_help="Show some information about the currently-playing video.")

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -180,11 +180,11 @@ class CastController:
     def volume(self, level):
         self.cast.set_volume(level)
 
-    def volumeup(self):
-        self.cast.volume_up()
+    def volumeup(self, delta):
+        self.cast.volume_up(delta)
 
-    def volumedown(self):
-        self.cast.volume_down()
+    def volumedown(self, delta):
+        self.cast.volume_down(delta)
 
     def status(self):
         status = self.cast.media_controller.status.__dict__


### PR DESCRIPTION
Now that we are using `pychromecast 0.8.0`, we can make use of a new feature: The ability to supply a delta to `volume_up` and `volume_down`. I have also used the opportunity to make the type of the value consistent with what we are using in `volume`.