### PR TITLE
fix: Further improve play_media

### DIFF
--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -1,8 +1,8 @@
-import threading
 import json
 import os
 import shutil
 import tempfile
+import threading
 import time
 
 import pychromecast

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -1,9 +1,9 @@
+import threading
 import json
 import os
 import shutil
 import tempfile
 import time
-import threading
 
 import pychromecast
 import youtube_dl


### PR DESCRIPTION
Hi. So while experimenting with listeners, I found out that `catt cast` does not work if run when the cc is already playing something (in an app other than the "Default Media Receiver"). I discussed this briefly with the friendly pychromecast people: https://github.com/balloob/pychromecast/issues/168

So I did my own listener that sets its own event, to use instead of `block_until_active` in `CastController.play_media`. I realize that this is getting a bit involved, but as you can see in the before mentioned discussion, `block_until_active` simply does not cut it in it's current form, for use in `CastController.play_media`.

EDIT: Sorry about the extra commits, my own flake8 did not complain about import order. And now CI is failing on python3, I have no idea why (the branch installs fine).