### PR TITLE
Another slight improvement to play_media

### DIFF
--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -177,8 +177,8 @@ class CastController:
             raise CattCastError("Nothing is currently playing.")
 
     def play_media(self, url, content_type="video/mp4"):
-        self.cast.play_media(url, content_type)
         self.cast.register_status_listener(self.listener)
+        self.cast.play_media(url, content_type)
         self.listener.ready.wait()
         self.cast.media_controller.block_until_active()
 


### PR DESCRIPTION
This is probably not going to make any difference in real use, but IMO it is better to register the listener before calling `media_controller.play_media`. With the current implementation there is a (very) slight chance that `self.listener.ready.wait()` will lock indefinitely.