### PR TITLE
Handle extractor fail

### DIFF
--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -31,7 +31,7 @@ def get_stream_info(video_url):
 
     try:
         info = ydl.process_ie_result(preinfo, download=False)
-    except youtube_dl.utils.ExtractorError:
+    except (youtube_dl.utils.ExtractorError, youtube_dl.utils.DownloadError):
         raise CattCastError("Youtube-dl extractor failed.")
 
     if msg:

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -29,7 +29,10 @@ def get_stream_info(video_url):
         preinfo = pre
         msg = None
 
-    info = ydl.process_ie_result(preinfo, download=False)
+    try:
+        info = ydl.process_ie_result(preinfo, download=False)
+    except youtube_dl.utils.ExtractorError:
+        raise CattCastError("Youtube-dl extractor failed.")
 
     if msg:
         echo("Warning: Playlists not supported, playing %s video." % msg,


### PR DESCRIPTION
Here's a link that makes `catt` crash: http://www.gdcvault.com/play/1014846/Conference-Keynote-Shigeru

I'm not entirely shure we need to check for `ExtractorError`, but best to leave it there.