### PR TITLE
Add skip command

### DIFF
--- a/catt/cli.py
+++ b/catt/cli.py
@@ -204,6 +204,13 @@ def seek(settings, timedesc):
     cst.seek(timedesc)
 
 
+@cli.command(short_help="Skip to end of video.")
+@click.pass_obj
+def skip(settings):
+    cst = CastController(settings["device"])
+    cst.skip()
+
+
 @cli.command(short_help="Set the volume to LVL [0-100].")
 @click.argument("level", type=click.IntRange(0, 100), metavar="LVL")
 @click.pass_obj

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -204,10 +204,12 @@ def seek(settings, timedesc):
     cst.seek(timedesc)
 
 
-@cli.command(short_help="Skip to end of video.")
+@cli.command(short_help="Skip to next video in YouTube Queue.")
 @click.pass_obj
 def skip(settings):
     cst = CastController(settings["device"])
+    if cst.cast.app_id != "233637DE":
+        raise CattCliError("YouTube Queue is currently not active.")
     cst.skip()
 
 

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -205,10 +205,10 @@ class CastController:
     def ffwd(self, seconds):
         pos = self.cast.media_controller.status.current_time
         self.seek(pos + seconds)
-    
+
     def skip(self):
         status = self.cast.media_controller.status.__dict__
-        
+
         if status["duration"]:
             self.seek(int(status["duration"]) + 1)
         else:

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -205,6 +205,14 @@ class CastController:
     def ffwd(self, seconds):
         pos = self.cast.media_controller.status.current_time
         self.seek(pos + seconds)
+    
+    def skip(self):
+        status = self.cast.media_controller.status.__dict__
+        
+        if status["duration"]:
+            self.seek(int(status["duration"]) + 1)
+        else:
+            raise CattCastError("Cannot skip live stream.")
 
     def volume(self, level):
         self.cast.set_volume(level)


### PR DESCRIPTION
Since the youtube controller currently does not support selecting which playlist entry to play, I thought that a simple `skip` command would be useful. When casting a youtube playlist this would make the app play the next entry (if any). The implementation is a bit of a hack, but it seems to work well.