### PR TITLE
Ensure DIAL info from all CC's

### DIFF
--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -146,7 +146,8 @@ class CastController:
                 raise ValueError
             self.cast = pychromecast.Chromecast(cached_ip)
         except (pychromecast.error.ChromecastConnectionError, ValueError):
-            self.cast = get_chromecast(device_name)
+            cast = get_chromecast(device_name)
+            self.cast = pychromecast.Chromecast(cast.host)
             cache.set(self.cast.name, self.cast.host)
 
         self.cast.wait()


### PR DESCRIPTION
Howdy.
So while tinkering with pychromecast in IPython I discovered something weird. It turns out that the cc info gathered when creating `Chromecast` objects differ, depending on whether you create it "manually" with an IP-adress or via auto-discovery. Pychromecast retrieves info via both zeroconf and DIAL, and those are unfortunately not exactly the same. The DIAL info is always retrieved. However when you use auto-discovery, the info retrieved via zeroconf overrides the DIAL info.

Please see: https://github.com/balloob/pychromecast/blob/master/pychromecast/__init__.py#L141

And thats a problem with regards to `catt` trying to determine cc model, because `model_name` might differ, depending on whether we use a cached ip or use auto-discovery. Thus this PR.

From my CC2:
```
In [2]: cast = pychromecast.Chromecast('192.168.1.21')

In [3]: cast.model_name
Out[3]: 'Eureka Dongle'

In [4]: casts = pychromecast.get_chromecasts()                  

In [5]: casts[1].model_name
Out[5]: 'Chromecast'
```
What is the corresponding info for your Mi Box?