### PR TITLE
Fix for StreamInfo.init

### DIFF
--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -49,7 +49,7 @@ class StreamInfo:
             if self.is_playlist:
                 items = list(self._preinfo["entries"])
                 self._first_entry_info = self._get_stream_info(items[0])
-                # Some playlist extractors does not provide an id key with entries,
+                # Some playlist extractors do not provide an id key with entries,
                 # so we need to tolerate that. _playlist_items is only required by
                 # custom controllers anyway.
                 try:

--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -49,6 +49,9 @@ class StreamInfo:
             if self.is_playlist:
                 items = list(self._preinfo["entries"])
                 self._first_entry_info = self._get_stream_info(items[0])
+                # Some playlist extractors does not provide an id key with entries,
+                # so we need to tolerate that. _playlist_items is only required by
+                # custom controllers anyway.
                 try:
                     self._playlist_items = [item["id"] for item in items]
                 except KeyError:

--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -49,7 +49,10 @@ class StreamInfo:
             if self.is_playlist:
                 items = list(self._preinfo["entries"])
                 self._first_entry_info = self._get_stream_info(items[0])
-                self._playlist_items = [item["id"] for item in items]
+                try:
+                    self._playlist_items = [item["id"] for item in items]
+                except KeyError:
+                    self._playlist_items = None
             else:
                 self._info = self._get_stream_info(self._preinfo)
 


### PR DESCRIPTION
Some playlist extractors (like ```bandcamp:album```) does not provide an ```id``` key with entries, so we need to tolerate that. Not really a problem, as ```_playlist_items``` only is needed by custom controllers.