### PR TITLE
Proper fix for add action

### DIFF
--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -110,7 +110,7 @@ def catch_namespace_error(func):
     """
     Use this decorator for methods in CastController subclasses where the intended
     action is dependant on the chromecast being in a particular state (such as not
-    buffering). If the cc app is then iterrupted during catt waiting for this state,
+    buffering). If the cc app is then interrupted while catt is waiting for this state,
     we fail in a nice way.
     """
 


### PR DESCRIPTION
I've ditched my previous attempt of solving this, and made a decorator that catches the namespace errors that is thrown when the cc app is interrupted while we are waiting for a particular state (such as not buffering).
While tinkering with this, I managed to get the YouTube controller to throw an "Don't add videos while we're buffering" exception. So I've split the listener into discrete "cast" and "media" parts, and that actually seems to have made things a bit more stable (the previous approach might have caused threading issues).