### PR TITLE
Cleanup n freeze

### DIFF
--- a/catt/cli.py
+++ b/catt/cli.py
@@ -96,11 +96,10 @@ def write_config(settings):
 @click.pass_obj
 def cast(settings, video_url):
     cst, stream = setup_cast(settings["device"], video_url=video_url, prep="app")
-    cc_name = cst.cast.device.friendly_name
 
     if stream.is_local_file:
         click.echo("Casting local file %s..." % video_url)
-        click.echo("Playing %s on \"%s\"..." % (stream.video_title, cc_name))
+        click.echo("Playing %s on \"%s\"..." % (stream.video_title, cst.cc_name))
 
         thr = Thread(target=serve_file,
                      args=(video_url, stream.local_ip, stream.port))
@@ -114,7 +113,7 @@ def cast(settings, video_url):
 
     elif stream.is_playlist:
         click.echo("Casting remote file %s..." % video_url)
-        click.echo("Playing %s on \"%s\"..." % (stream.playlist_title, cc_name))
+        click.echo("Playing %s on \"%s\"..." % (stream.playlist_title, cst.cc_name))
         try:
             cst.play_playlist(stream.playlist)
         except PlaybackError:
@@ -127,7 +126,7 @@ def cast(settings, video_url):
 
     else:
         click.echo("Casting remote file %s..." % video_url)
-        click.echo("Playing %s on \"%s\"..." % (stream.video_title, cc_name))
+        click.echo("Playing %s on \"%s\"..." % (stream.video_title, cst.cc_name))
         if cst.info_type == "url":
             cst.play_media_url(stream.video_url, title=stream.video_title,
                                thumb=stream.video_thumbnail)

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -287,10 +287,10 @@ class CastController:
         self.seek(pos + seconds)
 
     def skip(self):
-        status = self._cast.media_controller.status.__dict__
+        status = self._cast.media_controller.status
 
-        if status["duration"]:
-            self.seek(status["duration"] - 0.3)
+        if status.duration:
+            self.seek(status.duration - 0.3)
         else:
             raise CattCastError("Cannot skip live stream.")
 

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -318,7 +318,7 @@ class CastController:
             echo("Remaining time: %s" % remaining)
 
         echo("State: %s" % status.player_state)
-        echo("Volume: %s" % int(self._cast.status.volume_level * 100))
+        echo("Volume: %s" % round(self._cast.status.volume_level * 100))
 
     def info(self):
         # Values in media_controller.status for the keys "volume_level" and "volume_muted"

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open('README.rst') as readme_file:
 
 requirements = [
     "youtube-dl>=2017.3.15",
-    "PyChromecast>=0.8.0",
+    "PyChromecast==1.0.3",
     "Click>=5.0",
 ]
 


### PR DESCRIPTION
This should be the last PR for now.:sweat_smile:

+ I've made ```CastController.cast``` private, now that ```cli.cast``` only needs the cc name.
+ Made ```CastController.skip``` a bit prettier, no real change.
+ Freezed PyChromecast requirement, now that their next release will break Py2 support.
+ Minor change in how we display volume in ```status```, because of weird behaviour from PyChromecast 
   with regards to this (try ```catt info``` after you've adjusted volume).

I hope you don't mind me rolling this up in one PR, but I wanted to move on.

PS: I've temporarily ditched my efforts to implement a verbose option, as it breaks tests, and I honestly can't figure out how to fix them.