### PR TITLE
Make seek/status commands more useful with weird stream data

### DIFF
--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -300,7 +300,10 @@ class CastController:
         self.seek(pos + seconds)
 
     def skip(self):
-        self._cast.media_controller.skip()
+        if self._is_seekable:
+            self._cast.media_controller.skip()
+        else:
+            raise CattCastError("Stream is not skippable.")
 
     def volume(self, level):
         self._cast.set_volume(level)


### PR DESCRIPTION
(Yes, I'm procrastinating. :innocent:)

Recently my chromecast has begun reporting a duration of zero, with some content (that is seekable) from a local streaming outfit, meaning that `status` is not useful with these.
I taken this opportunity to make ```catt``` fail when the user tries to seek content, where it makes no sense.