### PR TITLE
Saner empty playlist check

### DIFF
--- a/catt/cli.py
+++ b/catt/cli.py
@@ -111,6 +111,9 @@ def cast(settings, video_url, force_default):
             time.sleep(1)
 
     elif stream.is_playlist:
+        if not stream.playlist:
+            cst.kill()
+            raise CattCliError("Playlist is empty.")
         click.echo("Casting remote file %s..." % video_url)
         click.echo("Playing %s on \"%s\"..." % (stream.playlist_title, cst.cc_name))
         try:

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -369,8 +369,6 @@ class YoutubeCastController(CastController):
         self._controller.play_video(video_id)
 
     def play_playlist(self, playlist):
-        if not playlist:
-            raise CattCastError("Playlist is empty.")
         self.play_media_id(playlist[0])
         if len(playlist) > 1:
             for video_id in playlist[1:]:

--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -51,7 +51,7 @@ class StreamInfo:
 
             if self.is_playlist:
                 items = list(self._preinfo["entries"])
-                self._first_entry_info = self._get_stream_info(items[0])
+                self._first_entry_info = self._get_stream_info(items[0]) if items else None
                 # Some playlist extractors do not provide an id key with entries,
                 # so we need to tolerate that. _playlist_items is only required by
                 # custom controllers anyway.


### PR DESCRIPTION
I've moved the check to ```cli.cast```, as that makes more sense. Otherwise, the ```play_playlist``` method of any custom controller would have to implement the check. While working on this, I came across a bug in ```stream_info``` that would make ```catt``` crash with empty playlists, so I fixed that.