### PR TITLE
Save/restore

### DIFF
--- a/catt/cli.py
+++ b/catt/cli.py
@@ -260,6 +260,7 @@ def save(settings):
         click.echo("Warning: Please be advised that playlist data will not be saved.",
                    err=True)
 
+    click.echo("Device: %s" % cst.cc_name)
     click.echo("Title: {title}\nTime: {human_time}\nSaving data...".format(**cst.save_data))
     state = CastState(CONFIG_DIR, STATE_FILENAME)
     state.set_data(cst.cc_name, {"controller": cst.name, "data": cst.save_data})
@@ -274,6 +275,7 @@ def restore(settings):
     if not data:
         raise CattCliError("No save data found for this device.")
 
+    click.echo("Device: %s" % cst.cc_name)
     click.echo("Title: {title}\nTime: {human_time}\nRestoring data...".format(**data["data"]))
     cst = setup_cast(settings["device"], prep="app", controller=data["controller"])
     cst.restore(data["data"])

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -259,7 +259,7 @@ def scan():
 @click.pass_obj
 def save(settings):
     cst = setup_cast(settings["device"], prep="control")
-    if not cst.save_capability:
+    if not cst.save_capability or cst.is_streaming_local_file:
         raise CattCliError("Saving state of this kind of content is not supported.")
     elif cst.save_capability == "partial":
         click.echo("Warning: Please be advised that playlist data will not be saved.",

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -18,8 +18,8 @@ from .http_server import serve_file
 
 
 CONFIG_DIR = Path(click.get_app_dir("catt"))
-CONFIG_FILE = Path(CONFIG_DIR, "catt.cfg")
-STATE_FILENAME = Path("state.json")
+CONFIG_PATH = Path(CONFIG_DIR, "catt.cfg")
+STATE_PATH = Path(CONFIG_DIR, "state.json")
 
 
 class CattCliError(click.ClickException):
@@ -267,7 +267,7 @@ def save(settings):
 
     print_status(cst.media_info)
     click.echo("Saving...")
-    state = CastState(CONFIG_DIR, STATE_FILENAME)
+    state = CastState(STATE_PATH)
     state.set_data(cst.cc_name, {"controller": cst.name, "data": cst.media_info})
 
 
@@ -275,7 +275,7 @@ def save(settings):
 @click.pass_obj
 def restore(settings):
     cst = setup_cast(settings["device"])
-    state = CastState(CONFIG_DIR, STATE_FILENAME)
+    state = CastState(STATE_PATH)
     data = state.get_data(cst.cc_name)
     if not data:
         raise CattCliError("No save data found for this device.")
@@ -326,7 +326,7 @@ def writeconfig(settings):
         for option, value in options.items():
             config.set(section, option, value)
 
-    with CONFIG_FILE.open("w") as configfile:
+    with CONFIG_PATH.open("w") as configfile:
         config.write(configfile)
 
 
@@ -339,7 +339,7 @@ def readconfig():
          "aliases": {"device1": "device_name"}}
     """
     config = configparser.ConfigParser()
-    config.read(CONFIG_FILE)
+    config.read(CONFIG_PATH)
     conf_dict = {section: dict(config.items(section)) for section in config.sections()}
 
     conf = conf_dict.get("options", {})

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -12,7 +12,8 @@ from .controllers import (
     get_chromecast,
     get_chromecasts,
     PlaybackError,
-    setup_cast
+    setup_cast,
+    StateFileError
 )
 from .http_server import serve_file
 
@@ -289,7 +290,10 @@ def save(settings, path):
 def restore(settings, path):
     cst = setup_cast(settings["device"])
     state = CastState(path or STATE_PATH)
-    data = state.get_data(cst.cc_name)
+    try:
+        data = state.get_data(cst.cc_name)
+    except StateFileError:
+        raise CattCliError("The chosen file is not a valid save file.")
     if not data:
         raise CattCliError("No save data found for this device.")
 

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -264,8 +264,8 @@ def scan():
 
 
 @cli.command(short_help="Save the current state of the Chromecast for later use.")
-@click.argument("path", type=click.Path(writable=True),
-                callback=process_path, required=False, metavar="PATH")
+@click.argument("path",
+                type=click.Path(writable=True), callback=process_path, required=False)
 @click.pass_obj
 def save(settings, path):
     cst = setup_cast(settings["device"], prep="control")
@@ -284,8 +284,8 @@ def save(settings, path):
 
 
 @cli.command(short_help="Return Chromecast to saved state.")
-@click.argument("path", type=click.Path(exists=True),
-                callback=process_path, required=False, metavar="PATH")
+@click.argument("path",
+                type=click.Path(exists=True), callback=process_path, required=False)
 @click.pass_obj
 def restore(settings, path):
     cst = setup_cast(settings["device"])

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -255,7 +255,7 @@ def scan():
 def save(settings):
     cst = setup_cast(settings["device"], prep="control")
     if not cst.save_capability:
-        raise CattCliError("Saving state of this Chromecast app is not supported.")
+        raise CattCliError("Saving state of this kind of content is not supported.")
     elif cst.save_capability == "partial":
         click.echo("Warning: Please be advised that playlist data will not be saved.",
                    err=True)

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -260,6 +260,7 @@ def save(settings):
         click.echo("Warning: Please be advised that playlist data will not be saved.",
                    err=True)
 
+    click.echo("Title: {title}\nTime: {time}\nSaving data...".format(**cst.save_data))
     state = CastState(CONFIG_DIR, STATE_FILENAME)
     state.set_data(cst.cc_name, {"controller": cst.name, "data": cst.save_data})
 
@@ -273,6 +274,7 @@ def restore(settings):
     if not data:
         raise CattCliError("No save data found for this device.")
 
+    click.echo("Title: {title}\nTime: {time}\nRestoring data...".format(**data["data"]))
     cst = setup_cast(settings["device"], prep="app", controller=data["controller"])
     cst.restore(data["data"])
 

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -260,7 +260,7 @@ def save(settings):
         click.echo("Warning: Please be advised that playlist data will not be saved.",
                    err=True)
 
-    click.echo("Title: {title}\nTime: {time}\nSaving data...".format(**cst.save_data))
+    click.echo("Title: {title}\nTime: {human_time}\nSaving data...".format(**cst.save_data))
     state = CastState(CONFIG_DIR, STATE_FILENAME)
     state.set_data(cst.cc_name, {"controller": cst.name, "data": cst.save_data})
 
@@ -274,7 +274,7 @@ def restore(settings):
     if not data:
         raise CattCliError("No save data found for this device.")
 
-    click.echo("Title: {title}\nTime: {time}\nRestoring data...".format(**data["data"]))
+    click.echo("Title: {title}\nTime: {human_time}\nRestoring data...".format(**data["data"]))
     cst = setup_cast(settings["device"], prep="app", controller=data["controller"])
     cst.restore(data["data"])
 

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -286,7 +286,8 @@ class CastController:
     def restore(self, data):
         """
         Recreate Chromecast state from save data.
-        Subclasses must implement this.
+        Subclasses can implement this if its possible to recreate
+        a session from the save data.
         """
 
         raise NotImplementedError

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -280,7 +280,9 @@ class CastController:
     def save_data(self):
         status = self._cast.media_controller.status
         return {"url_or_id": status.content_id,
-                "time": status.current_time, "title": status.title,
+                "title": status.title,
+                "time": status.current_time,
+                "human_time": self._human_time(status.current_time),
                 "thumb": status.images[0].url if status.images else None}
 
     def restore(self, data):

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -102,7 +102,8 @@ def setup_cast(device_name, video_url=None, prep=None, controller=None):
         except StopIteration:
             app = DEFAULT_APP
 
-    if app["app_name"] != "default" and cast.cast_type not in app["supported_device_types"]:
+    if (not controller and app["app_name"] != "default" and
+        cast.cast_type not in app["supported_device_types"]):
         if stream:
             echo("Warning: The %s app is not available for this device." % app["app_name"].capitalize(),
                  err=True)

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -140,20 +140,19 @@ class PlaybackError(Exception):
 
 
 class CattStore:
-    def __init__(self, store_dir, store_filename):
-        self.store_dir = store_dir
+    def __init__(self, store_path):
+        self.store_path = store_path
         try:
-            self.store_dir.mkdir()
+            self.store_path.parent.mkdir()
         except FileExistsError:
             pass
-        self.store_file = Path(self.store_dir, store_filename)
 
     def _read_store(self):
-        with self.store_file.open() as store:
+        with self.store_path.open() as store:
             return json.load(store)
 
     def _write_store(self, data):
-        with self.store_file.open("w") as store:
+        with self.store_path.open("w") as store:
             json.dump(data, store)
 
     def get_data(self, *args):
@@ -166,19 +165,18 @@ class CattStore:
 
     def clear(self):
         try:
-            self.store_file.unlink()
-            self.store_dir.rmdir()
+            self.store_path.unlink()
+            self.store_path.parent.rmdir()
         except FileNotFoundError:
             pass
 
 
 class Cache(CattStore):
     def __init__(self):
-        cache_dir = Path(tempfile.gettempdir(), "catt_cache")
-        cache_filename = Path("chromecast_hosts")
-        super(Cache, self).__init__(cache_dir, cache_filename)
+        cache_path = Path(tempfile.gettempdir(), "catt_cache", "chromecast_hosts")
+        super(Cache, self).__init__(cache_path)
 
-        if not self.store_file.exists():
+        if not self.store_path.exists():
             devices = pychromecast.get_chromecasts()
             self._write_store({d.name: d.host for d in devices})
 
@@ -196,10 +194,10 @@ class Cache(CattStore):
 
 
 class CastState(CattStore):
-    def __init__(self, state_dir, state_filename):
-        super(CastState, self).__init__(state_dir, state_filename)
+    def __init__(self, state_path):
+        super(CastState, self).__init__(state_path)
 
-        if not self.store_file.exists():
+        if not self.store_path.exists():
             self._write_store({})
 
     def get_data(self, name):

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -103,7 +103,7 @@ def setup_cast(device_name, video_url=None, prep=None, controller=None):
             app = DEFAULT_APP
 
     if (not controller and app["app_name"] != "default" and
-        cast.cast_type not in app["supported_device_types"]):
+            cast.cast_type not in app["supported_device_types"]):
         if stream:
             echo("Warning: The %s app is not available for this device." % app["app_name"].capitalize(),
                  err=True)

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -135,6 +135,10 @@ class CattCastError(ClickException):
     pass
 
 
+class StateFileError(Exception):
+    pass
+
+
 class PlaybackError(Exception):
     pass
 
@@ -201,8 +205,14 @@ class CastState(CattStore):
             self._write_store({})
 
     def get_data(self, name):
-        data = self._read_store()
-        return data.get(name)
+        try:
+            data = self._read_store()
+            save_data = data.get(name)
+            if save_data and set(save_data.keys()) != set(["controller", "data"]):
+                raise ValueError
+        except (json.decoder.JSONDecodeError, ValueError):
+            raise StateFileError
+        return save_data
 
 
 class CastStatusListener:

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -302,6 +302,11 @@ class CastController:
         return cinfo
 
     @property
+    def is_streaming_local_file(self):
+        status = self._cast.media_controller.status
+        return True if status.content_id.endswith("?loaded_from_catt") else False
+
+    @property
     def _is_seekable(self):
         status = self._cast.media_controller.status
         return True if (status.duration and

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -411,7 +411,8 @@ class DefaultCastController(CastController):
     def __init__(self, cast, name, app_id, prep=None):
         super(DefaultCastController, self).__init__(cast, name, app_id, prep=prep)
         self.info_type = "url"
-        self.save_capability = "complete" if self._cast.app_id == DEFAULT_APP["app_id"] else None
+        self.save_capability = "complete" if (self._is_seekable and
+                                              self._cast.app_id == DEFAULT_APP["app_id"]) else None
 
     def play_media_url(self, video_url, **kwargs):
         self._controller.play_media(video_url, "video/mp4",

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -58,6 +58,10 @@ def setup_cast(device_name, video_url=None, prep=None, controller=None):
                  if the desired action can be carried out regardless of the
                  state of the chromecast (like volume adjustment).
     :type prep: str
+    :param controller: If supplied, the normal logic for determining the appropriate
+                       controller is bypassed, and the one specified here is
+                       returned instead.
+    :type controller: str
     :returns: controllers.DefaultCastController or controllers.YoutubeCastController,
               and stream_info.StreamInfo if video_url is supplied.
     """

--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -97,7 +97,7 @@ class StreamInfo:
     @property
     def video_url(self):
         if self.is_local_file:
-            return "http://%s:%s/" % (self.local_ip, self.port)
+            return "http://%s:%s/?loaded_from_catt" % (self.local_ip, self.port)
         elif self.is_playlist:
             return None
         else:

--- a/tests/test_catt.py
+++ b/tests/test_catt.py
@@ -31,12 +31,12 @@ class TestThings(unittest.TestCase):
 
     def test_cache(self):
         cache = Cache()
-        cache.set("key", "value")
-        self.assertEqual(cache.get("key"), "value")
+        cache.set_data("key", "value")
+        self.assertEqual(cache.get_data("key"), "value")
 
         cache.clear()
         cache = Cache()
-        self.assertEqual(cache.get("key"), None)
+        self.assertEqual(cache.get_data("key"), None)
         cache.clear()
 
 


### PR DESCRIPTION
Hi.
This appears to be working pretty well, but still has some issues that need to be resolved:

+ ~~This does not work for local file casting. This also means that ```cli.save``` needs to be able to determine whether an active stream is from a local file. I can't think of a non-hackish way of doing this, the way the code is currently organized.~~
+ ~~Time descriptions in messages to the user are not in human time.~~
+ ~~Current logic in ```DefaultCastController``` excludes all cc-apps but the default from save functionality. The problem with that is that the "Stylized media receiver" apps are identical functionality-wise to the default one, meaning that save/restore would work with them. There seems to be no easy way to tell a "stylized" app apart from a "custom" one (where save/restore would not work without a custom controller), as both have unique app id's. Namespaces do also not seem to provide anything to uniquely identify a cc app as one thing or the other.~~ I'll deal with the "stylized" app stuff in a later PR.
+ ~~Give the user the ability to select arbitrary save location.~~

