### PR TITLE
Use create dir when saving state to config dir

### DIFF
--- a/catt/cli.py
+++ b/catt/cli.py
@@ -290,7 +290,7 @@ def save(settings, path):
     if path and path.exists():
         click.confirm("File already exists. Overwrite?", abort=True)
     click.echo("Saving...")
-    state = CastState(path or STATE_PATH)
+    state = CastState(path or STATE_PATH, create_dir=True if not path else False)
     state.set_data(cst.cc_name, {"controller": cst.name, "data": cst.media_info})
 
 

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -201,9 +201,10 @@ class Cache(CattStore):
 
 
 class CastState(CattStore):
-    def __init__(self, state_path):
+    def __init__(self, state_path, create_dir=False):
         super(CastState, self).__init__(state_path)
-
+        if create_dir:
+            self._create_store_dir()
         if not self.store_path.exists():
             self._write_store({})
 


### PR DESCRIPTION
A bug creeped in, that would make ```catt``` crash if the user were to save (with no save path specified) without the config dir existing.