### PR TITLE
fix: Use netifaces instead of socket for get_local_ip

### DIFF
--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -81,7 +81,7 @@ def setup_cast(device_name, video_url=None, prep=None, controller=None):
 
     if video_url:
         cc_info = (cast.device.manufacturer, cast.model_name)
-        stream = StreamInfo(video_url, model=cc_info, host=cast.host)
+        stream = StreamInfo(video_url, model=cc_info)
 
     if controller:
         if controller == "default":

--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -1,8 +1,8 @@
 import random
-import socket
 from pathlib import Path
 
 import click
+import netifaces
 import youtube_dl
 
 
@@ -26,10 +26,10 @@ class CattInfoError(click.ClickException):
 
 
 class StreamInfo:
-    def __init__(self, video_url, model=None, host=None):
+    def __init__(self, video_url, model=None):
         if "://" not in video_url:
             self._local_file = video_url
-            self.local_ip = self._get_local_ip(host)
+            self.local_ip = self._get_local_ip()
             self.port = random.randrange(45000, 47000)
             self.is_local_file = True
         else:
@@ -149,10 +149,9 @@ class StreamInfo:
             else:
                 self._active_entry = self._entries[number]
 
-    def _get_local_ip(self, cc_host):
-        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        sock.connect((cc_host, 0))
-        return sock.getsockname()[0]
+    def _get_local_ip(self):
+        interface = netifaces.gateways()['default'][netifaces.AF_INET][1]
+        return netifaces.ifaddresses(interface)[netifaces.AF_INET][0]['addr']
 
     def _get_stream_preinfo(self, video_url):
         try:

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@ requirements = [
     "youtube-dl>=2017.3.15",
     "PyChromecast>=2.0.0",
     "Click>=5.0",
+    "netifaces>=0.10.7",
+    "requests>=2.18.4",
 ]
 
 test_requirements = [


### PR DESCRIPTION
fixes #99

Currently, ```netifaces``` and ```requests``` are not in our install requirements. Should they be, now that we are importing them ourselves?