### PR TITLE
Support to Cast Any Website to Chromecast (via DashCast)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Cast All The Things
 
 Cast All The Things allows you to send videos from many, many online sources
 (YouTube, Vimeo, and a few hundred others) to your Chromecast. It also allows
-you to cast local files or tell Chromecast to render URLs.
+you to cast local files or render websites.
 
 
 Installation
@@ -33,25 +33,26 @@ To use Cast All The Things, just specify a URL::
 
     catt cast "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
 
-CATT supports any service that youtube-dl supports, which includes most online
+``catt`` supports any service that youtube-dl supports, which includes most online
 video hosting services.
 
-CATT can also cast local files (if they're in a format the Chromecast supports
+``catt`` can also cast local files (if they're in a format the Chromecast supports
 natively)::
 
     catt cast ./myvideo.mp4
 
-If you have subtitles and the name is similar to the local file, CATT will add them automatically.
+If you have subtitles and the name is similar to the name of the local file, ``catt`` will add them automatically.
 You can, of course, specify any other subtitle if you want. Although Chromecast only supports WEBVTT,
-TTML and Line 21 subtitles, CATT conveniently converts SRTs to WEBVTT for you on the fly. Here is how to use it:
+TTML and Line 21 subtitles, ``catt`` conveniently converts SRTs to WEBVTT for you on the fly. Here is how to use it:
 
     catt cast -s ./mysubtitle.srt /myvideo.mp4
 
-CATT can also tell your Chromecast to display any website::
+``catt`` can also tell your Chromecast to display any website::
 
     catt cast_url https://en.wikipedia.org/wiki/Rickrolling
 
-Please notice that Chromecast has a slow CPU but a reasonably recent version of Google Chrome. The display resolution is 1280x720
+Please note that the Chromecast has a slow CPU but a reasonably recent version of Google Chrome. The display
+resolution is 1280x720.
 
 You can also control your Chromecast through ``catt`` commands, for example with
 ``catt pause``. Try running ``catt --help`` to see the full list of commands.
@@ -88,11 +89,11 @@ edit ``catt.cfg``
 Contributing
 ------------
 
-If you want to contribute a feature to CATT, please open an issue (or comment on
+If you want to contribute a feature to ``catt``, please open an issue (or comment on
 an existing one) first, to make sure it's something that the maintainers are
 interested in. Afterwards, just clone the repository and hack away!
 
-To run CATT in development, you can use the following command::
+To run ``catt`` in development, you can use the following command::
 
     python -m catt.cli --help
 

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Cast All The Things
 
 Cast All The Things allows you to send videos from many, many online sources
 (YouTube, Vimeo, and a few hundred others) to your Chromecast. It also allows
-you to cast local files.
+you to cast local files or tell Chromecast to render URLs.
 
 
 Installation
@@ -40,6 +40,18 @@ CATT can also cast local files (if they're in a format the Chromecast supports
 natively)::
 
     catt cast ./myvideo.mp4
+
+If you have subtitles and the name is similar to the local file, CATT will add them automatically.
+You can, of course, specify any other subtitle if you want. Although Chromecast only supports WEBVTT,
+TTML and Line 21 subtitles, CATT conveniently converts SRTs to WEBVTT for you on the fly. Here is how to use it:
+
+    catt cast -s ./mysubtitle.srt /myvideo.mp4
+
+CATT can also tell your Chromecast to display any website::
+
+    catt cast_url https://en.wikipedia.org/wiki/Rickrolling
+
+Please notice that Chromecast has a slow CPU but a reasonably recent version of Google Chrome. The display resolution is 1280x720
 
 You can also control your Chromecast through ``catt`` commands, for example with
 ``catt pause``. Try running ``catt --help`` to see the full list of commands.
@@ -97,3 +109,6 @@ Features
 
 * Casts videos to Chromecast.
 * From `many, many online sources <http://rg3.github.io/youtube-dl/supportedsites.html>`_.
+* Casts local files (videos, photos and music)
+* Casts any website to Chromecast
+

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -251,7 +251,7 @@ def cast(settings, video_url, subtitle, force_default, random_play, no_subs):
             cst.play_media_id(stream.playlist_entry_id)
 
     else:
-        click.echo("Casting remote url %s..." % video_url)
+        click.echo("Casting remote file %s..." % video_url)
         click.echo("Playing %s on \"%s\"..." % (stream.video_title, cst.cc_name))
         if cst.info_type == "url":
             cst.play_media_url(stream.video_url, title=stream.video_title,

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -181,7 +181,7 @@ def process_subtitle(ctx, param, value):
     return value
 
 
-@cli.command(short_help="Makes your Chromecast display any webpage")
+@cli.command(short_help="Cast any webpage to Chromecast")
 @click.argument("url")
 @click.pass_obj
 def cast_url(settings, url):

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -242,7 +242,7 @@ def cast(settings, video_url, subtitle, force_default, random_play, no_subs):
             cst.play_media_id(stream.playlist_entry_id)
 
     else:
-        click.echo("Casting remote file %s..." % video_url)
+        click.echo("Casting remote url %s..." % video_url)
         click.echo("Playing %s on \"%s\"..." % (stream.video_title, cst.cc_name))
         if cst.info_type == "url":
             cst.play_media_url(stream.video_url, title=stream.video_title,

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -10,12 +10,10 @@ from threading import Thread
 
 import click
 import requests
-from pychromecast.controllers.dashcast import APP_DASHCAST as DASHCAST_APP_ID
 
 from .controllers import (
     Cache,
     CastState,
-    CattCastError,
     get_chromecast,
     get_chromecasts,
     PlaybackError,
@@ -187,35 +185,7 @@ def process_subtitle(ctx, param, value):
 @click.argument("url")
 @click.pass_obj
 def cast_url(settings, url):
-    app_ready = "Application ready"
-    try:
-        info_controller = setup_cast(settings["device"], prep="control").info
-        if info_controller["app_id"] == DASHCAST_APP_ID and info_controller["status_text"] != app_ready:
-            print("Removing old website...")
-            setup_cast(settings["device"]).kill()
-            while True:
-                time.sleep(1)
-                info_controller = setup_cast(settings["device"], prep="control").info
-                if info_controller["app_id"] != DASHCAST_APP_ID:
-                    break
-    except CattCastError as e:
-        if e.message == "Chromecast is inactive.":
-            pass
-        else:
-            raise e
-
     cst = setup_cast(settings["device"], prep="app", controller="dashcast")
-    print("Loading DashCast...")
-    cst.load_url(url)
-    while True:
-        try:
-            info_controller = setup_cast(settings["device"], prep="control").info
-            if info_controller["app_id"] == DASHCAST_APP_ID and info_controller["status_text"] != app_ready:
-                break
-        except CattCastError as e:
-            if e.message == "Chromecast is inactive.":
-                pass
-        time.sleep(1)
     click.echo("Casting URL %s on \"%s\"..." % (url, cst.cc_name))
     cst.load_url(url)
 

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -9,11 +9,13 @@ from pathlib import Path
 from threading import Thread
 
 import click
+from pychromecast.controllers.dashcast import APP_DASHCAST as DASHCAST_APP_ID
 import requests
 
 from .controllers import (
     Cache,
     CastState,
+    CattCastError,
     get_chromecast,
     get_chromecasts,
     PlaybackError,
@@ -179,6 +181,48 @@ def process_subtitle(ctx, param, value):
         raise CattCliError("Subtitle file [{}] does not exist".format(value))
 
     return value
+
+@cli.command(short_help="Makes your Chromecast display any webpage")
+@click.argument("url")
+@click.pass_obj
+def cast_url(settings, url):
+    app_ready = "Application ready"
+    try:
+        info_controller = setup_cast(settings["device"], prep="control").info
+        if info_controller["app_id"] == DASHCAST_APP_ID and info_controller["status_text"] != app_ready:
+            print("Removing old website...")
+            setup_cast(settings["device"]).kill()
+            time.sleep(5)
+            while True:
+                info_controller = setup_cast(settings["device"], prep="control").info
+                if info_controller["app_id"] != DASHCAST_APP_ID:
+                    break
+                time.sleep(1)
+    except CattCastError as e:
+        if e.message == "Chromecast is inactive.":
+            pass
+        else:
+            raise e
+
+    cst, stream = setup_cast(settings["device"], video_url=url, prep="dashcast", controller="dashcast")
+
+    print("Loading DashCast...")
+    cst.play_media_url(stream.video_url, title=stream.video_title,
+                       thumb=stream.video_thumbnail,
+                       content_type=stream.guessed_content_type)
+    while True:
+        try:
+            info_controller = setup_cast(settings["device"], prep="control").info
+            if info_controller["app_id"] == DASHCAST_APP_ID and info_controller["status_text"] != app_ready:
+                break
+        except CattCastError as e:
+            if e.message == "Chromecast is inactive.":
+                pass
+        time.sleep(1)
+    click.echo("Casting URL %s on \"%s\"..." % (stream.video_title, cst.cc_name))
+    cst.play_media_url(stream.video_url, title=stream.video_title,
+                       thumb=stream.video_thumbnail,
+                       content_type=stream.guessed_content_type)
 
 
 @cli.command(short_help="Send a video to a Chromecast for playing.")

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -13,7 +13,10 @@ from .util import warning
 from .youtube import YouTubeController
 
 
-APP_INFO = [{"app_name": "youtube", "app_id": "233637DE", "supported_device_types": ["cast"]}]
+APP_INFO = [
+    {"app_name": "youtube", "app_id": "233637DE", "supported_device_types": ["cast"]},
+    {"app_name": "dashcast", "app_id": DASHCAST_APP_ID, "supported_device_types": ["cast"]},
+]
 DEFAULT_APP = {"app_name": "default", "app_id": "CC1AD845"}
 DASHCAST_APP = {"app_name": "dashcast", "app_id": DASHCAST_APP_ID}
 BACKDROP_APP_ID = "E8C28D3C"
@@ -83,10 +86,8 @@ def setup_cast(device_name, video_url=None, prep=None, controller=None):
     cast.wait()
 
     if controller == "dashcast":
-        cc_info = (cast.device.manufacturer, cast.model_name)
         controller = DashCastController(cast, DASHCAST_APP["app_name"], DASHCAST_APP["app_id"], prep=prep)
-        stream = StreamInfo(video_url, model=cc_info, is_standard_website=True)
-        return (controller, stream)
+        return controller
 
     if video_url:
         cc_info = (cast.device.manufacturer, cast.model_name)
@@ -344,7 +345,7 @@ class CastController:
     def _prep_control(self):
         """Make shure chromecast is in an active state."""
 
-        if self._cast.app_id == DASHCAST_APP["app_id"]:
+        if self._cast.app_id == DASHCAST_APP_ID:
             return
         if self._cast.app_id == BACKDROP_APP_ID or not self._cast.app_id:
             raise CattCastError("Chromecast is inactive.")
@@ -463,10 +464,9 @@ class DashCastController(CastController):
     def __init__(self, cast, name, app_id, prep=None):
         self._controller = PyChromecastDashCastController()
         super(DashCastController, self).__init__(cast, name, app_id, prep=prep)
-        self.info_type = "url"
 
-    def play_media_url(self, video_url, **kwargs):
-        self._controller.load_url(video_url, force=True)
+    def load_url(self, url, **kwargs):
+        self._controller.load_url(url, force=True)
 
 
 class YoutubeCastController(CastController):

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -82,12 +82,15 @@ def setup_cast(device_name, video_url=None, prep=None, controller=None):
         cache.set_data(cast.name, cast.host)
     cast.wait()
 
+    if controller == "dashcast":
+        cc_info = (cast.device.manufacturer, cast.model_name)
+        controller = DashCastController(cast, DASHCAST_APP["app_name"], DASHCAST_APP["app_id"], prep=prep)
+        stream = StreamInfo(video_url, model=cc_info, is_standard_website=True)
+        return (controller, stream)
+
     if video_url:
         cc_info = (cast.device.manufacturer, cast.model_name)
-        stream = StreamInfo(video_url, model=cc_info, host=cast.host)
-        if stream.is_standard_website:
-            controller = DashCastController(cast, DASHCAST_APP["app_name"], DASHCAST_APP["app_id"], prep=prep)
-            return (controller, stream)
+        stream = StreamInfo(video_url, model=cc_info)
 
     if controller:
         if controller == "default":
@@ -118,6 +121,7 @@ def setup_cast(device_name, video_url=None, prep=None, controller=None):
         controller = YoutubeCastController(cast, app["app_name"], app["app_id"], prep=prep)
     else:
         controller = DefaultCastController(cast, app["app_name"], app["app_id"], prep=prep)
+
     return (controller, stream) if stream else controller
 
 

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -480,6 +480,9 @@ class DashCastController(CastController):
     def _prep_app(self):
         """Make sure desired chromecast app is running."""
         if self._cast.app_id == DASHCAST_APP_ID:
+            # After a URL is loaded, the loaded page assumes control of Chromecast
+            # and therefore ignore any future command we to DashCast.
+            # Albeit annoying, the solution is quite simple: we kill the dashcast app.
             self._cast_listener.set_app_id(BACKDROP_APP_ID, self._cast.app_id)
             self.kill()
             self._cast_listener.app_ready.wait()

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -477,7 +477,7 @@ class DashCastController(CastController):
         self._load_url(url)  # this will actually take us to the "Waiting for URL" screen
         while not self._is_waiting_for_url():
             time.sleep(1)
-        self._load_url(url)
+        self._load_url(url)  # this will finally load the URL
 
     def _load_url(self, url, **kwargs):
         self._controller.load_url(url, force=True)

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -121,7 +121,6 @@ def setup_cast(device_name, video_url=None, prep=None, controller=None):
         controller = DashCastController(cast, app["app_name"], app["app_id"], prep=prep)
     else:
         controller = DefaultCastController(cast, app["app_name"], app["app_id"], prep=prep)
-
     return (controller, stream) if stream else controller
 
 
@@ -231,9 +230,9 @@ class CastState(CattStore):
 
 class CastStatusListener:
     def __init__(self, app_id, active_app_id):
+        self.app_id = app_id
         self.app_ready = threading.Event()
         self.backdrop_ready = threading.Event()
-        self.app_id = app_id
         self._clear_or_set_backdrop_event(active_app_id)
         if app_id == active_app_id:
             self.app_ready.set()

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -234,8 +234,6 @@ class CastStatusListener:
         self.app_ready = threading.Event()
         if app_id == active_app_id and app_id != DASHCAST_APP_ID:
             self.app_ready.set()
-        else:
-            self.app_ready.clear()
 
     def new_cast_status(self, status):
         if self._is_app_ready(status):

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -357,8 +357,6 @@ class CastController:
 
     def _prep_control(self):
         """Make sure chromecast is in an active state."""
-        if self._cast.app_id == DASHCAST_APP_ID:
-            return
         if self._cast.app_id == BACKDROP_APP_ID or not self._cast.app_id:
             raise CattCastError("Chromecast is inactive.")
         self._cast.media_controller.block_until_active(1.0)

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -19,7 +19,6 @@ APP_INFO = [
     {"app_name": "dashcast", "app_id": DASHCAST_APP_ID, "supported_device_types": ["cast"]},
 ]
 DEFAULT_APP = {"app_name": "default", "app_id": "CC1AD845"}
-DASHCAST_APP = {"app_name": "dashcast", "app_id": DASHCAST_APP_ID}
 BACKDROP_APP_ID = "E8C28D3C"
 
 
@@ -86,10 +85,6 @@ def setup_cast(device_name, video_url=None, prep=None, controller=None):
         cache.set_data(cast.name, cast.host)
     cast.wait()
 
-    if controller == "dashcast":
-        controller = DashCastController(cast, DASHCAST_APP["app_name"], DASHCAST_APP["app_id"], prep=prep)
-        return controller
-
     if video_url:
         cc_info = (cast.device.manufacturer, cast.model_name)
         stream = StreamInfo(video_url, model=cc_info)
@@ -121,6 +116,8 @@ def setup_cast(device_name, video_url=None, prep=None, controller=None):
 
     if app["app_name"] == "youtube":
         controller = YoutubeCastController(cast, app["app_name"], app["app_id"], prep=prep)
+    elif app["app_name"] == "dashcast":
+        controller = DashCastController(cast, app["app_name"], app["app_id"], prep=prep)
     else:
         controller = DefaultCastController(cast, app["app_name"], app["app_id"], prep=prep)
 

--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -2,7 +2,6 @@ import random
 from pathlib import Path
 
 import netifaces
-
 import youtube_dl
 
 from .util import guess_mime

--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -28,16 +28,7 @@ class CattInfoError(click.ClickException):
 
 
 class StreamInfo:
-    def __init__(self, video_url, model=None, is_standard_website=False):
-        self.is_standard_website = is_standard_website
-        if self.is_standard_website:
-            self.is_local_file = False
-            self.local_ip = None
-            self.port = None
-            self._video_url = video_url
-            self.is_standard_website = True
-            return
-
+    def __init__(self, video_url, model=None):
         if "://" not in video_url:
             self._local_file = video_url
             self.local_ip = self._get_local_ip()
@@ -72,20 +63,14 @@ class StreamInfo:
 
     @property
     def is_playlist(self):
-        if self.is_standard_website:
-            return False
         return not self.is_local_file and "entries" in self._preinfo
 
     @property
     def extractor(self):
-        if self.is_standard_website:
-            return None
         return self._preinfo["extractor"].split(":")[0] if not self.is_local_file else None
 
     @property
     def video_title(self):
-        if self.is_standard_website:
-            return self.video_url
         if self.is_local_file:
             return Path(self._local_file).name
         elif self.is_playlist:
@@ -100,8 +85,6 @@ class StreamInfo:
 
     @property
     def video_url(self):
-        if self.is_standard_website:
-            return self._video_url
         if self.is_local_file:
             return "http://%s:%s/?loaded_from_catt" % (self.local_ip, self.port)
         elif self.is_playlist:
@@ -111,20 +94,14 @@ class StreamInfo:
 
     @property
     def video_id(self):
-        if self.is_standard_website:
-            return self.video_url
         return self._preinfo["id"] if self.is_remote_file else None
 
     @property
     def video_thumbnail(self):
-        if self.is_standard_website:
-            return None
         return self._preinfo.get("thumbnail") if self.is_remote_file else None
 
     @property
     def guessed_content_type(self):
-        if self.is_standard_website:
-            return None
         if self.is_local_file:
             return guess_mime(self.video_title)
         elif self.is_remote_file and self._info.get("direct"):


### PR DESCRIPTION
In another step to make `catt` cast ALL the things, here is a simple PR to make it cast any website to Chromecast.

The heavy lifting is done by DashCast ( http://stestagg.github.io/dashcast/ ), which was easier than I thought to implement on `catt` because `pychromecast` already supports it.

I decided not to change the UI by falling back to `dastcast` every time `youtube-dl` can not handle a URL.

That means you just needs to type:

`catt cast https://www.github.com/` 

to see github on your chromecast!

`catt info` shows the title of the webpage that is being displayed.