### PR TITLE
fix: Make save restore more robust

### DIFF
--- a/catt/cli.py
+++ b/catt/cli.py
@@ -362,7 +362,7 @@ def save(settings, path):
     if path and path.is_file():
         click.confirm("File already exists. Overwrite?", abort=True)
     click.echo("Saving...")
-    state = CastState(path or STATE_PATH, create_dir=True if not path else False)
+    state = CastState(path or STATE_PATH, mode="arbi" if path else "conf")
     state.set_data(cst.cc_name, {"controller": cst.name, "data": cst.media_info})
 
 
@@ -370,6 +370,8 @@ def save(settings, path):
 @click.argument("path", type=click.Path(exists=True), callback=process_path, required=False)
 @click.pass_obj
 def restore(settings, path):
+    if not path and not STATE_PATH.is_file():
+        raise CattCliError("Save file in config dir has not been created.")
     cst = setup_cast(settings["device"])
     state = CastState(path or STATE_PATH)
     try:

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -11,7 +11,7 @@ from threading import Thread
 import click
 import requests
 
-from .controllers import Cache, CastState, StateFileError, get_chromecast, get_chromecasts, setup_cast
+from .controllers import Cache, CastState, StateFileError, StateMode, get_chromecast, get_chromecasts, setup_cast
 from .http_server import serve_file
 from .util import warning
 
@@ -362,7 +362,10 @@ def save(settings, path):
     if path and path.is_file():
         click.confirm("File already exists. Overwrite?", abort=True)
     click.echo("Saving...")
-    state = CastState(path or STATE_PATH, mode="arbi" if path else "conf")
+    if path:
+        state = CastState(path, StateMode.ARBI)
+    else:
+        state = CastState(STATE_PATH, StateMode.CONF)
     state.set_data(cst.cc_name, {"controller": cst.name, "data": cst.media_info})
 
 
@@ -373,7 +376,7 @@ def restore(settings, path):
     if not path and not STATE_PATH.is_file():
         raise CattCliError("Save file in config dir has not been created.")
     cst = setup_cast(settings["device"])
-    state = CastState(path or STATE_PATH)
+    state = CastState(path or STATE_PATH, StateMode.READ)
     try:
         data = state.get_data(cst.cc_name)
     except StateFileError:

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -205,12 +205,18 @@ class Cache(CattStore):
 
 
 class CastState(CattStore):
-    def __init__(self, state_path, create_dir=False):
+    def __init__(self, state_path, mode="read"):
         super(CastState, self).__init__(state_path)
-        if create_dir:
+        if mode == "conf":
             self._create_store_dir()
-        if not self.store_path.is_file():
+            if not self.store_path.is_file():
+                self._write_store({})
+        elif mode == "arbi":
             self._write_store({})
+        elif mode == "read":
+            pass
+        else:
+            raise ValueError("invalid mode")
 
     def get_data(self, name):
         try:

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -1,6 +1,7 @@
 import json
 import tempfile
 import threading
+from enum import Enum, auto
 from pathlib import Path
 
 import pychromecast
@@ -204,19 +205,21 @@ class Cache(CattStore):
         return data.get(name)
 
 
+class StateMode(Enum):
+    READ = auto()
+    CONF = auto()
+    ARBI = auto()
+
+
 class CastState(CattStore):
-    def __init__(self, state_path, mode="read"):
+    def __init__(self, state_path, mode):
         super(CastState, self).__init__(state_path)
-        if mode == "conf":
+        if mode == StateMode.CONF:
             self._create_store_dir()
             if not self.store_path.is_file():
                 self._write_store({})
-        elif mode == "arbi":
+        elif mode == StateMode.ARBI:
             self._write_store({})
-        elif mode == "read":
-            pass
-        else:
-            raise ValueError("invalid mode")
 
     def get_data(self, name):
         try:


### PR DESCRIPTION
A few improvements:
+ We now fail with the correct error message, if the user tries ```catt restore```, without any config dir save file having been created.
+ I've made an attempt at making the create dir/file logic less flakey.