### PR TITLE
Fix bug introduced in latest StreamInfo refactor

### DIFF
--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -102,11 +102,11 @@ class StreamInfo:
 
     @property
     def video_id(self):
-        return self._info["id"] if self.is_remote_file else None
+        return self._info["id"] if self.is_remote_file or self._is_playlist_with_active_entry else None
 
     @property
     def video_thumbnail(self):
-        return self._info.get("thumbnail") if self.is_remote_file else None
+        return self._info.get("thumbnail") if self.is_remote_file or self._is_playlist_with_active_entry else None
 
     @property
     def guessed_content_type(self):


### PR DESCRIPTION
..id's and thumbnails were not returned for active playlist entries.

The missing id could only be triggered by something like:
```catt cast -r 'https://www.youtube.com/watch?v=CIvzV5ZdYis&list=PLQNHYNv9IpSzzaQMuH7ji2bEy6o8T8Wwn'```
I've added this to my testing scheme now.
