### PR TITLE
Make use of enums in CastState even safer

### DIFF
--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -213,6 +213,8 @@ class StateMode(Enum):
 
 class CastState(CattStore):
     def __init__(self, state_path, mode):
+        if not isinstance(mode, StateMode):
+            raise ValueError("invalid mode")
         super(CastState, self).__init__(state_path)
         if mode == StateMode.CONF:
             self._create_store_dir()

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -212,9 +212,7 @@ class StateMode(Enum):
 
 
 class CastState(CattStore):
-    def __init__(self, state_path, mode):
-        if not isinstance(mode, StateMode):
-            raise ValueError("invalid mode")
+    def __init__(self, state_path: Path, mode: StateMode):
         super(CastState, self).__init__(state_path)
         if mode == StateMode.CONF:
             self._create_store_dir()

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -212,7 +212,7 @@ class StateMode(Enum):
 
 
 class CastState(CattStore):
-    def __init__(self, state_path: Path, mode: StateMode):
+    def __init__(self, state_path: Path, mode: StateMode) -> None:
         super(CastState, self).__init__(state_path)
         if mode == StateMode.CONF:
             self._create_store_dir()


### PR DESCRIPTION
It occurs to me that we would have to do something like this, for this to be safe. Or just check for all possible attributes of the enum and then do ```else fail```, like I did before. Is there any convention/best practice when doing this kind of stuff in python?