### PR TITLE
Group support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,8 @@ repos:
     rev: v1.3.0
     hooks:
     -   id: flake8
+-   repo: git://github.com/skorokithakis/pre-commit-mypy
+    rev: v0.1.0
+    hooks:
+    - id: mypy
+      args: [-s]

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -28,8 +28,7 @@ def get_chromecasts(fail=True):
         raise CattCastError("No devices found.")
 
     devices.sort(key=lambda cc: cc.name)
-    # We need to ensure that all Chromecast objects contain DIAL info.
-    return [pychromecast.Chromecast(cc.host) for cc in devices]
+    return devices
 
 
 def get_chromecast(device_name):

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -21,10 +21,10 @@ DEFAULT_APP = {"app_name": "default", "app_id": "CC1AD845"}
 BACKDROP_APP_ID = "E8C28D3C"
 
 
-def get_chromecasts():
+def get_chromecasts(fail=True):
     devices = pychromecast.get_chromecasts()
 
-    if not devices:
+    if fail and not devices:
         raise CattCastError("No devices found.")
 
     devices.sort(key=lambda cc: cc.name)
@@ -189,7 +189,7 @@ class Cache(CattStore):
         self._create_store_dir()
 
         if not self.store_path.is_file():
-            devices = pychromecast.get_chromecasts()
+            devices = get_chromecasts(fail=False)
             self._write_store({d.name: d.host for d in devices})
 
     def get_data(self, name):

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -19,6 +19,7 @@ APP_INFO = [
 ]
 DEFAULT_APP = {"app_name": "default", "app_id": "CC1AD845"}
 BACKDROP_APP_ID = "E8C28D3C"
+DEVICES_WITH_TWO_MODEL_NAMES = {"Eureka Dongle": "Chromecast"}
 
 
 def get_chromecasts(fail=True):
@@ -84,7 +85,8 @@ def setup_cast(device_name, video_url=None, prep=None, controller=None):
     cast.wait()
 
     if video_url:
-        cc_info = (cast.device.manufacturer, cast.model_name)
+        model_name = DEVICES_WITH_TWO_MODEL_NAMES.get(cast.model_name, cast.model_name)
+        cc_info = (cast.device.manufacturer, model_name)
         stream = StreamInfo(video_url, model=cc_info)
 
     if controller:

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import tempfile
 import threading
@@ -189,7 +190,8 @@ class CattStore:
 
 class Cache(CattStore):
     def __init__(self):
-        cache_path = Path(tempfile.gettempdir(), "catt_%s_cache" % CATT_VERSION, "chromecast_hosts")
+        vhash = hashlib.sha1(CATT_VERSION.encode()).hexdigest()[:8]
+        cache_path = Path(tempfile.gettempdir(), "catt_%s_cache" % vhash, "chromecast_hosts")
         super(Cache, self).__init__(cache_path)
         self._create_store_dir()
 

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -87,7 +87,7 @@ def setup_cast(device_name, video_url=None, prep=None, controller=None):
     if video_url:
         model_name = DEVICES_WITH_TWO_MODEL_NAMES.get(cast.model_name, cast.model_name)
         cc_info = (cast.device.manufacturer, model_name)
-        stream = StreamInfo(video_url, model=cc_info)
+        stream = StreamInfo(video_url, model=cc_info, device_type=cast.cast_type)
 
     if controller:
         if controller == "default":

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -172,13 +172,11 @@ class CattStore:
         with self.store_path.open("w") as store:
             json.dump(data, store)
 
-    def get_data(self, *args):
-        raise NotImplementedError
+    # def get_data(self, *args):
+    #     raise NotImplementedError
 
-    def set_data(self, name, value):
-        data = self._read_store()
-        data[name] = value
-        self._write_store(data)
+    # def set_data(self, *args):
+    #     raise NotImplementedError
 
     def clear(self):
         try:
@@ -220,7 +218,7 @@ class Cache(CattStore):
             fetched = data[min(data, key=str)]
         return (fetched["ip"], fetched.get("group_port")) if fetched else (None, None)
 
-    def set_data(self, name, ip, port):
+    def set_data(self, name: str, ip: str, port: int) -> None:
         data = self._read_store()
         data[name] = self._create_device_entry(ip, port)
         self._write_store(data)
@@ -242,7 +240,7 @@ class CastState(CattStore):
         elif mode == StateMode.ARBI:
             self._write_store({})
 
-    def get_data(self, name):
+    def get_data(self, name: str) -> str:
         try:
             data = self._read_store()
             if set(next(iter(data.values())).keys()) != set(["controller", "data"]):
@@ -250,6 +248,11 @@ class CastState(CattStore):
         except (json.decoder.JSONDecodeError, ValueError, StopIteration, AttributeError):
             raise StateFileError
         return data.get(name)
+
+    def set_data(self, name, value):
+        data = self._read_store()
+        data[name] = value
+        self._write_store(data)
 
 
 class CastStatusListener:

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -209,7 +209,7 @@ class Cache(CattStore):
         # In the case that cache has been initialized with no cc's on the
         # network, we need to ensure auto-discovery.
         if not data:
-            return None
+            return (None, None)
         if name:
             fetched = data.get(name)
         else:

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -9,6 +9,7 @@ from click import ClickException, echo
 from pychromecast.controllers.dashcast import APP_DASHCAST as DASHCAST_APP_ID
 from pychromecast.controllers.dashcast import DashCastController as PyChromecastDashCastController
 
+from .__init__ import __version__ as CATT_VERSION
 from .stream_info import StreamInfo
 from .util import warning
 from .youtube import YouTubeController
@@ -185,7 +186,7 @@ class CattStore:
 
 class Cache(CattStore):
     def __init__(self):
-        cache_path = Path(tempfile.gettempdir(), "catt_cache", "chromecast_hosts")
+        cache_path = Path(tempfile.gettempdir(), "catt_%s_cache" % CATT_VERSION, "chromecast_hosts")
         super(Cache, self).__init__(cache_path)
         self._create_store_dir()
 

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -4,7 +4,6 @@ import tempfile
 import threading
 from enum import Enum
 from pathlib import Path
-from typing import Any, Optional, Tuple, Union
 
 import pychromecast
 from click import ClickException, echo
@@ -173,10 +172,10 @@ class CattStore:
         with self.store_path.open("w") as store:
             json.dump(data, store)
 
-    def get_data(self, *args: Any) -> Tuple[Optional[bytes], Union[None, int, str]]:
+    def get_data(self, *args):
         raise NotImplementedError
 
-    def set_data(self, *args: Any) -> None:
+    def set_data(self, *args) -> None:
         raise NotImplementedError
 
     def clear(self):
@@ -205,7 +204,7 @@ class Cache(CattStore):
             device_data["group_port"] = port
         return device_data
 
-    def get_data(self, name: str) -> Tuple[Union[None, bytes], Union[None, int]]:  # type: ignore
+    def get_data(self, name: str):  # type: ignore
         data = self._read_store()
         # In the case that cache has been initialized with no cc's on the
         # network, we need to ensure auto-discovery.
@@ -241,7 +240,7 @@ class CastState(CattStore):
         elif mode == StateMode.ARBI:
             self._write_store({})
 
-    def get_data(self, name: str) -> Tuple[Union[None, bytes], Union[None, str]]:  # type: ignore
+    def get_data(self, name: str):  # type: ignore
         try:
             data = self._read_store()
             if set(next(iter(data.values())).keys()) != set(["controller", "data"]):

--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -7,7 +7,7 @@ import youtube_dl
 
 from .util import guess_mime
 
-AUDIO_MODELS = [("Google Inc.", "Chromecast Audio")]
+AUDIO_DEVICE_TYPES = ["audio", "group"]
 ULTRA_MODELS = [("Xiaomi", "MIBOX3"), ("Google Inc.", "Chromecast Ultra")]
 
 BEST_MAX_2K = "best[width <=? 1920][height <=? 1080]"
@@ -31,7 +31,7 @@ class StreamInfoError(Exception):
 
 
 class StreamInfo:
-    def __init__(self, video_url, model=None):
+    def __init__(self, video_url, model=None, device_type=None):
         if "://" not in video_url:
             self._local_file = video_url
             self.local_ip = self._get_local_ip()
@@ -47,7 +47,7 @@ class StreamInfo:
             self.port = None
             self.is_local_file = False
 
-            if model in AUDIO_MODELS:
+            if device_type in AUDIO_DEVICE_TYPES:
                 self._best_format = AUDIO_FORMAT
             elif model in ULTRA_MODELS:
                 self._best_format = ULTRA_FORMAT

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("README.rst") as readme_file:
 
 requirements = ["youtube-dl>=2017.3.15", "PyChromecast>=2.0.0", "Click>=5.0", "netifaces>=0.10.7", "requests>=2.18.4"]
 
-test_requirements = []
+test_requirements = []  # type: ignore
 
 setup(
     name="catt",

--- a/tests/test_catt.py
+++ b/tests/test_catt.py
@@ -31,12 +31,12 @@ class TestThings(unittest.TestCase):
 
     def test_cache(self):
         cache = Cache()
-        cache.set_data("key", "value")
-        self.assertEqual(cache.get_data("key"), "value")
+        cache.set_data("name", "ip", "port")
+        self.assertEqual(cache.get_data("name"), ("ip", "port"))
 
         cache.clear()
         cache = Cache()
-        self.assertEqual(cache.get_data("key"), None)
+        self.assertEqual(cache.get_data("name"), (None, None))
         cache.clear()
 
 


### PR DESCRIPTION
We are now assuming that 1st/2nd gen. chromecasts are the only kinds of devices that report different names via DIAL/zeroconf.

fixes #119

Please test, as I do not have access to multiple audio devices myself.