### PR TITLE
Dashcast update

### DIFF
--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -525,7 +525,7 @@ class DashCastController(CastController):
 
         # We must force the launch of the DashCast app because it, by design,
         # becomes unresponsive after a website is loaded.
-        self._cast.socket_client.receiver_controller.launch_app(self._cast_listener.app_id, force_launch=True)
+        self._cast.start_app(self._cast_listener.app_id, force_launch=True)
         self._cast_listener.app_ready.wait()
 
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except ImportError:
 with open("README.rst") as readme_file:
     readme = readme_file.read()
 
-requirements = ["youtube-dl>=2017.3.15", "PyChromecast>=2.0.0", "Click>=5.0", "netifaces>=0.10.7", "requests>=2.18.4"]
+requirements = ["youtube-dl>=2017.3.15", "PyChromecast>=2.3.0", "Click>=5.0", "netifaces>=0.10.7", "requests>=2.18.4"]
 
 test_requirements = []  # type: ignore
 


### PR DESCRIPTION
The Dashcast/```cast_site``` functionality currently relies on a [hack](https://github.com/skorokithakis/catt/pull/102#issuecomment-390633433), in order for repeated uses of ```cast_site``` to work.

Marcosdiez submitted a PR to Pychromecast, that was merged, and now has been included in the new ```2.3.0``` release.