### PR TITLE
Make save files portable

### DIFF
--- a/catt/cli.py
+++ b/catt/cli.py
@@ -387,9 +387,11 @@ def save(settings, path):
     click.echo("Saving...")
     if path:
         state = CastState(path, StateMode.ARBI)
+        cc_name = "*"
     else:
         state = CastState(STATE_PATH, StateMode.CONF)
-    state.set_data(cst.cc_name, {"controller": cst.name, "data": cst.media_info})
+        cc_name = cst.cc_name
+    state.set_data(cc_name, {"controller": cst.name, "data": cst.media_info})
 
 
 @cli.command(short_help="Return Chromecast to saved state.")
@@ -401,7 +403,7 @@ def restore(settings, path):
     cst = setup_cast(settings["device"])
     state = CastState(path or STATE_PATH, StateMode.READ)
     try:
-        data = state.get_data(cst.cc_name)
+        data = state.get_data(cst.cc_name if not path else None)
     except StateFileError:
         raise CattCliError("The chosen file is not a valid save file.")
     if not data:

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -117,16 +117,19 @@ def setup_cast(device_name, video_url=None, prep=None, controller=None, ytdl_opt
         except StopIteration:
             app = DEFAULT_APP
 
-    if not controller and app["app_name"] != "default" and cast.cast_type not in app["supported_device_types"]:
-        if stream:
-            warning("The %s app is not available for this device." % app["app_name"].capitalize())
+    if app["app_name"] != "default" and cast.cast_type not in app["supported_device_types"]:
+        msg = "The %s app is not available for this device." % app["app_name"].capitalize()
+        if controller:
+            raise CattCastError(msg)
+        elif stream:
+            warning(msg)
         app = DEFAULT_APP
 
     if app["app_name"] == "youtube":
         controller = YoutubeCastController(cast, app["app_name"], app["app_id"], prep=prep)
-    elif app["app_name"] == "dashcast":
-        if cast.cast_type not in app["supported_device_types"]:
-            raise CattCastError("The %s app is not available for this device." % app["app_name"].capitalize())
+    # We also check for controller, in the unlikely event that youtube-dl
+    # gets an extractor named "dashcast".
+    elif app["app_name"] == "dashcast" and controller:
         controller = DashCastController(cast, app["app_name"], app["app_id"], prep=prep)
     else:
         controller = DefaultCastController(cast, app["app_name"], app["app_id"], prep=prep)

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -254,7 +254,10 @@ class CastState(CattStore):
                 raise ValueError
         except (json.decoder.JSONDecodeError, ValueError, StopIteration, AttributeError):
             raise StateFileError
-        return data.get(name)
+        if name:
+            return data.get(name)
+        else:
+            return next(iter(data.values()))
 
     def set_data(self, name: str, value: str) -> None:  # type: ignore
         data = self._read_store()


### PR DESCRIPTION
Currently, an entry in a save file is tied to a specific device, which means that the save file can't be used elsewhere. I've tried to fix that, while keeping backwards compability with existing save files.
We still use real device names in ```~/.config/catt/state.json```.