### PR TITLE
Switch from netifaces to ifaddr for get_local_ip

### DIFF
--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -96,7 +96,9 @@ def setup_cast(device_name, video_url=None, prep=None, controller=None, ytdl_opt
     if video_url:
         model_name = DEVICES_WITH_TWO_MODEL_NAMES.get(cast.model_name, cast.model_name)
         cc_info = (cast.device.manufacturer, model_name)
-        stream = StreamInfo(video_url, model=cc_info, device_type=cast.cast_type, ytdl_options=ytdl_options)
+        stream = StreamInfo(
+            video_url, model=cc_info, host=cast.host, device_type=cast.cast_type, ytdl_options=ytdl_options
+        )
 
     if controller:
         if controller == "default":

--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -2,7 +2,7 @@ import random
 from pathlib import Path
 
 import click
-import netifaces
+import ifaddr
 import youtube_dl
 
 from .util import guess_mime
@@ -149,8 +149,8 @@ class StreamInfo:
             raise StreamInfoError("called on non-playlist")
 
     def _get_local_ip(self):
-        interface = netifaces.gateways()["default"][netifaces.AF_INET][1]
-        return netifaces.ifaddresses(interface)[netifaces.AF_INET][0]["addr"]
+        adapter = next(a for a in ifaddr.get_adapters() if not any(i.ip == "127.0.0.1" for i in a.ips))
+        return adapter.ips[0].ip
 
     def _get_stream_preinfo(self, video_url):
         try:

--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -151,15 +151,17 @@ class StreamInfo:
 
     def _get_local_ip(self, host):
         for adapter in ifaddr.get_adapters():
-            for aip in adapter.ips:
+            for adapter_ip in adapter.ips:
+                aip = adapter_ip.ip[0] if isinstance(adapter_ip.ip, tuple) else adapter_ip.ip
                 try:
-                    ipaddress.IPv4Address(aip.ip)
-                except ipaddress.AddressValueError:
+                    if not isinstance(ipaddress.ip_address(host), type(ipaddress.ip_address(aip))):
+                        raise ValueError
+                except ValueError:
                     continue
-                catt_net = ipaddress.ip_network("%s/%s" % (aip.ip, aip.network_prefix), strict=False)
-                cc_net = ipaddress.ip_network("%s/%s" % (host, aip.network_prefix), strict=False)
+                ipt = [(ip, adapter_ip.network_prefix) for ip in (aip, host)]
+                catt_net, cc_net = [ipaddress.ip_network("%s/%s" % ip, strict=False) for ip in ipt]
                 if catt_net == cc_net:
-                    return aip.ip
+                    return aip
                 else:
                     continue
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except ImportError:
 with open("README.rst") as readme_file:
     readme = readme_file.read()
 
-requirements = ["youtube-dl>=2017.3.15", "PyChromecast>=2.3.0", "Click>=5.0", "netifaces>=0.10.7", "requests>=2.18.4"]
+requirements = ["youtube-dl>=2017.3.15", "PyChromecast>=2.3.0", "Click>=5.0", "ifaddr>=0.1.4", "requests>=2.18.4"]
 
 test_requirements = []  # type: ignore
 


### PR DESCRIPTION
```zeroconf``` have switched from ```netifaces``` to ```ifaddr``` (which, unlike ```netifaces```, is pure python), thus this PR.

```ifaddr``` is very simple though, and does not offer a means of identifying what interface the system considers to be the default, so I've attempted to implement something that returns the same(ish). Seems to work on Linux, but am not shure about macOS and Windows.