### PR TITLE
User format

### DIFF
--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -180,8 +180,6 @@ class StreamInfo:
             return self._ydl.process_ie_result(preinfo, download=False)
         except (youtube_dl.utils.ExtractorError, youtube_dl.utils.DownloadError):
             raise CattInfoError("Youtube-dl extractor failed.")
-        except ValueError:
-            raise CattInfoError("The specified format filter is invalid.")
 
     def _get_stream_url(self, info):
         try:

--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -49,7 +49,11 @@ class StreamInfo:
             self.port = None
             self.is_local_file = False
 
-            if device_type in AUDIO_DEVICE_TYPES:
+            if "format" in self._ydl.params:
+                # We pop the "format" item, as it will make get_stream_info fail,
+                # if it holds an invalid value.
+                self._best_format = self._ydl.params.pop("format")
+            elif device_type in AUDIO_DEVICE_TYPES:
                 self._best_format = AUDIO_FORMAT
             elif model in ULTRA_MODELS:
                 self._best_format = ULTRA_FORMAT
@@ -176,9 +180,14 @@ class StreamInfo:
             return self._ydl.process_ie_result(preinfo, download=False)
         except (youtube_dl.utils.ExtractorError, youtube_dl.utils.DownloadError):
             raise CattInfoError("Youtube-dl extractor failed.")
+        except ValueError:
+            raise CattInfoError("The specified format filter is invalid.")
 
     def _get_stream_url(self, info):
-        format_selector = self._ydl.build_format_selector(self._best_format)
+        try:
+            format_selector = self._ydl.build_format_selector(self._best_format)
+        except ValueError:
+            raise CattInfoError("The specified format filter is invalid.")
 
         try:
             best_format = next(format_selector(info))


### PR DESCRIPTION
We now use format filters specified by the user e.g. ```catt cast -y "format=[format_id=480p]" <url>```.