### PR TITLE
Fix typo in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ be selected, when you have not selected a device via the cli.
 
 You can write your choice of default device to ``catt.cfg`` by doing::
 
-    catt -d <name_of_chromecast> write_config
+    catt -d <name_of_chromecast> write-config
 
 In the ``[aliases]`` section, you can specify aliases for the names of your
 chromecasts. You can then select a device just by doing::


### PR DESCRIPTION
fixes #131

(The CI failure is because of a broken extractor, there's an open PR to ```youtube-dl``` that fixes it.)