### PR TITLE
fix: Give correct error messages with Dashcast

### DIFF
--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -129,9 +129,9 @@ def setup_cast(device_name, video_url=None, prep=None, controller=None, ytdl_opt
 
     if app["app_name"] == "youtube":
         controller = YoutubeCastController(cast, app["app_name"], app["app_id"], prep=prep)
-    # We also check for controller, in the unlikely event that youtube-dl
-    # gets an extractor named "dashcast".
-    elif app["app_name"] == "dashcast" and controller:
+    # We make these checks in order to avoid problems,
+    # in the unlikely event that youtube-dl gets an extractor named "dashcast".
+    elif controller == "dashcast" or (app["app_name"] == "dashcast" and not stream):
         controller = DashCastController(cast, app["app_name"], app["app_id"], prep=prep)
     else:
         controller = DefaultCastController(cast, app["app_name"], app["app_id"], prep=prep)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except ImportError:
 with open("README.rst") as readme_file:
     readme = readme_file.read()
 
-requirements = ["youtube-dl>=2017.3.15", "PyChromecast>=2.3.0", "Click>=5.0", "ifaddr>=0.1.4", "requests>=2.18.4"]
+requirements = ["youtube-dl>=2018.10.5", "PyChromecast>=2.3.0", "Click>=5.0", "ifaddr>=0.1.4", "requests>=2.18.4"]
 
 test_requirements = []  # type: ignore
 

--- a/tests/test_catt.py
+++ b/tests/test_catt.py
@@ -23,11 +23,11 @@ class TestThings(unittest.TestCase):
         self.assertEqual(stream.extractor, "youtube")
 
     def test_stream_info_other_video(self):
-        stream = StreamInfo("http://www.dailymotion.com/video/x6fotne")
+        stream = StreamInfo("https://clips.twitch.tv/CloudyEnticingChickpeaCeilingCat")
         self.assertIn("https://", stream.video_url)
-        self.assertEqual(stream.video_id, "x6fotne")
+        self.assertEqual(stream.video_id, "304482431")
         self.assertTrue(stream.is_remote_file)
-        self.assertEqual(stream.extractor, "dailymotion")
+        self.assertEqual(stream.extractor, "twitch")
 
     def test_cache(self):
         cache = Cache()


### PR DESCRIPTION
Because of my earlier "fix", the wrong ```CastController``` was being returned if the Dashcast app was running on the cc. Resulting in irrelevant error messages when issuing a control command (which the dashcast ```CastController``` does not support).

The CI failure is still because of the DailyMotion extractor, which was fixed in the latest release of ```youtube-dl```. Any ideas? Or should we just update requirements?