### PR TITLE
fix: Correct cast_site and write_config command names

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ be selected, when you have not selected a device via the cli.
 
 You can write your choice of default device to ``catt.cfg`` by doing::
 
-    catt -d <name_of_chromecast> write-config
+    catt -d <name_of_chromecast> write_config
 
 In the ``[aliases]`` section, you can specify aliases for the names of your
 chromecasts. You can then select a device just by doing::

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -97,7 +97,7 @@ def cli(ctx, delete_cache, device):
     ctx.obj["device"] = device
 
 
-@cli.command(short_help="Write the name of default Chromecast device to config file.")
+@cli.command("write_config", short_help="Write the name of default Chromecast device to config file.")
 @click.pass_obj
 def write_config(settings):
     if settings.get("device"):
@@ -254,7 +254,7 @@ def cast(settings, video_url, subtitle, force_default, random_play, no_subs, ytd
                 time.sleep(1)
 
 
-@cli.command(short_help="Cast any website to a Chromecast.")
+@cli.command("cast_site", short_help="Cast any website to a Chromecast.")
 @click.argument("url", callback=process_url)
 @click.pass_obj
 def cast_site(settings, url):


### PR DESCRIPTION
..as ```click``` (7.0+) has begun replacing underscores with dashes in command names that are derived from function names.
This was the cause of the confusion in #131, something I didn't pick up on, as it's been ages since I've last used the ```write_config``` command.
You should consider making a release, to avoid further confusion.