### PR TITLE
Prep method fixes

### DIFF
--- a/catt/cli.py
+++ b/catt/cli.py
@@ -268,7 +268,7 @@ def cast_site(settings, url):
 @click.pass_obj
 def add(settings, video_url):
     cst, stream = setup_cast(settings["device"], video_url=video_url, prep="control")
-    if (cst.name != "default" and cst.name != stream.extractor) or not stream.is_remote_file:
+    if cst.playlist_capability and (cst.name != stream.extractor or not stream.is_remote_file):
         raise CattCliError("This url cannot be added to the queue.")
     cst.add(stream.video_id)
 

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -352,14 +352,14 @@ def volumedown(settings, delta):
 @cli.command(short_help="Show some information about the currently-playing video.")
 @click.pass_obj
 def status(settings):
-    cst = setup_cast(settings["device"], prep="control")
+    cst = setup_cast(settings["device"], prep="info")
     print_status(cst.cast_info)
 
 
 @cli.command(short_help="Show complete information about the currently-playing video.")
 @click.pass_obj
 def info(settings):
-    cst = setup_cast(settings["device"], prep="control")
+    cst = setup_cast(settings["device"], prep="info")
     for (key, value) in cst.info.items():
         click.echo("%s: %s" % (key, value))
 

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -21,6 +21,7 @@ APP_INFO = [
 ]
 DEFAULT_APP = {"app_name": "default", "app_id": "CC1AD845"}
 BACKDROP_APP_ID = "E8C28D3C"
+NO_PLAYER_STATE_IDS = ["84912283"]
 DEVICES_WITH_TWO_MODEL_NAMES = {"Eureka Dongle": "Chromecast"}
 DEFAULT_PORT = 8009
 
@@ -403,9 +404,9 @@ class CastController:
     @property
     def _is_idle(self):
         status = self._cast.media_controller.status
-        # Dashcast (and maybe others) returns player_state == "UNKNOWN" while being active.
-        # Checking stream_type appears to be reliable.
-        return status.player_state in ["UNKNOWN", "IDLE"] and status.stream_type != "UNKNOWN"
+        # Dashcast (and maybe others) returns player_state == "UNKNOWN" while being active,
+        # so we maintain a list of those apps.
+        return status.player_state in ["UNKNOWN", "IDLE"] and self._cast.app_id not in NO_PLAYER_STATE_IDS
 
     def _prep_app(self):
         """Make sure desired chromecast app is running."""

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -342,6 +342,8 @@ class CastController:
             self._prep_app()
         elif prep == "control":
             self._prep_control()
+        elif prep == "info":
+            self._prep_info()
 
     @property
     def cc_name(self):
@@ -416,13 +418,22 @@ class CastController:
             self._cast_listener.app_ready.wait()
 
     def _prep_control(self):
-        """Make sure chromecast is in an active state."""
+        """Make sure chromecast is not inactive or idle."""
 
-        if self._cast.app_id == BACKDROP_APP_ID or not self._cast.app_id:
-            raise CattCastError("Chromecast is inactive.")
+        self._check_inactive()
         self._cast.media_controller.block_until_active(1.0)
         if self._is_idle:
             raise CattCastError("Nothing is currently playing.")
+
+    def _prep_info(self):
+        """Make sure chromecast is not inactive."""
+
+        self._check_inactive()
+        self._cast.media_controller.block_until_active(1.0)
+
+    def _check_inactive(self):
+        if self._cast.app_id == BACKDROP_APP_ID or not self._cast.app_id:
+            raise CattCastError("Chromecast is inactive.")
 
     def play_media_url(self, video_url, **kwargs):
         """


### PR DESCRIPTION
After a recent cc firmware upgrade, the behaviour of the cc after end of playback has changed if such a way, that the extra ```stream_type``` check in ```is_idle``` is no longer reliable. So I've resorted to a solution that Google can't break.
Also, I've introduced a new ```prep_info``` method so ```info``` and ```status``` commands are always available (as long as the cc is active).
Finally, I've sneaked in a slight improvement to url validation in ```cli.add```, in an attempt to weed out a few scenarios with irrelevant error msgs.