### PR TITLE
Add format hack for free Bandcamp content

### DIFF
--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -16,9 +16,11 @@ BEST_FALLBACK = "/best"
 MAX_50FPS = "[fps <=? 50]"
 TWITCH_NO_60FPS = "[format_id != 1080p60__source_][format_id != 720p60]"
 MIXCLOUD_NO_DASH = "[format_id != dash-a1-x3]"
-AUDIO_FORMAT = BEST_ONLY_AUDIO + MIXCLOUD_NO_DASH + BEST_FALLBACK
+BANDCAMP_NO_AIFF_ALAC = "[format_id != aiff-lossless][format_id != alac]"
+AUDIO_FORMAT = BEST_ONLY_AUDIO + MIXCLOUD_NO_DASH + BANDCAMP_NO_AIFF_ALAC + BEST_FALLBACK
 ULTRA_FORMAT = BEST_MAX_4K
 STANDARD_FORMAT = BEST_MAX_2K + MAX_50FPS + TWITCH_NO_60FPS
+
 DEFAULT_YTDL_OPTS = {"quiet": True, "no_warnings": True}
 
 


### PR DESCRIPTION
With "name your price" or free content, you can stream hi-res formats from Bandcamp, some of which are not supported by the cc audio (normally there's only the preview stream, which is mp3-128kb).