### PR TITLE
fix: Try to eliminate spurious error msgs when seeking

### DIFF
--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -381,10 +381,16 @@ class CastController:
             raise CastError("Chromecast is inactive")
 
     def _update_status(self):
-        listener = SimpleListener()
-        self._cast.media_controller.register_status_listener(listener)
-        self._cast.media_controller.update_status()
-        listener.block_until_status_received()
+        def get_status():
+            listener = SimpleListener()
+            self._cast.media_controller.register_status_listener(listener)
+            self._cast.media_controller.update_status()
+            listener.block_until_status_received()
+            return self._cast.media_controller.status
+
+        status = get_status()
+        if status.current_time and not status.content_id:
+            get_status()
 
     @property
     def cc_name(self):

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -381,16 +381,19 @@ class CastController:
             raise CastError("Chromecast is inactive")
 
     def _update_status(self):
-        def get_status():
+        # Under rare circumstances, a lot of fields are not populated in the updated status.
+        # This causes unexpected results in the is_idle logic of this class (among others).
+        # An extra update appears to weed out these incomplete statuses.
+        def update():
             listener = SimpleListener()
             self._cast.media_controller.register_status_listener(listener)
             self._cast.media_controller.update_status()
             listener.block_until_status_received()
-            return self._cast.media_controller.status
 
-        status = get_status()
+        update()
+        status = self._cast.media_controller.status
         if status.current_time and not status.content_id:
-            get_status()
+            update()
 
     @property
     def cc_name(self):


### PR DESCRIPTION
This passes both testing schemes, so is ready to merge. And it is definitely an improvement over the previous approach.

:guitar: :violin: :musical_keyboard: 