### PR TITLE
feat: Add ability to use ip-address as device argument 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## Unreleased
+
+### Fixes
+
+* Try to eliminate spurious error msgs when seeking (#194) [theychx]
+
+
 ## v0.9.5 (2019-03-26)
 
 ### Fixes

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -14,7 +14,7 @@ from . import __version__
 from .controllers import Cache, CastState, StateFileError, StateMode, get_chromecast, get_chromecasts, setup_cast
 from .error import CastError, CattUserError, CliError, SubsEncodingError
 from .http_server import serve_file
-from .util import convert_srt_to_webvtt, echo_json, human_time, hunt_subtitle, read_srt_subs, warning
+from .util import convert_srt_to_webvtt, echo_json, human_time, hunt_subtitle, is_ipaddress, read_srt_subs, warning
 
 CONFIG_DIR = Path(click.get_app_dir("catt"))
 CONFIG_PATH = Path(CONFIG_DIR, "catt.cfg")
@@ -73,11 +73,11 @@ def process_path(ctx, param, value):
     return path
 
 
-def get_device(ctx, param, value):
-    try:
-        return ctx.default_map["aliases"][value]
-    except KeyError:
+def process_device(ctx, param, value):
+    if is_ipaddress(value):
         return value
+    else:
+        return ctx.default_map["aliases"].get(value, value)
 
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
@@ -85,7 +85,7 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 @click.group(context_settings=CONTEXT_SETTINGS)
 @click.option("--delete-cache", is_flag=True, help="Empty the Chromecast discovery cache.")
-@click.option("-d", "--device", metavar="NAME", callback=get_device, help="Select Chromecast device.")
+@click.option("-d", "--device", metavar="NAME_OR_IP", callback=process_device, help="Select Chromecast device.")
 @click.version_option(version=__version__, prog_name="catt", message="%(prog)s v%(version)s, Winter Waterfall.")
 @click.pass_context
 def cli(ctx, delete_cache, device):

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -74,6 +74,13 @@ def process_path(ctx, param, value):
 
 
 def process_device(ctx, param, value):
+    """
+    Resolve real device name when value is an alias.
+
+    :param value: Can be an ip-address or a name (alias or real name).
+    :type value: str
+    """
+
     if is_ipaddress(value):
         return value
     else:

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -70,6 +70,15 @@ def get_chromecast_with_ip(device_ip, port=DEFAULT_PORT):
 
 
 def get_cast(device=None):
+    """
+    Attempt to connect with requested device (or any device if none has been specified).
+
+    :param device: Can be an ip-address or a name.
+    :type device: str
+    :returns: Chromecast object for use in a CastController.
+    :rtype: pychromecast.Chromecast
+    """
+
     cast = None
 
     if device and is_ipaddress(device):

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -17,7 +17,7 @@ from pychromecast.controllers.youtube import YouTubeController
 from .__init__ import __version__ as CATT_VERSION
 from .error import AppSelectionError, CastError, ControllerError, ListenerError, StateFileError
 from .stream_info import StreamInfo
-from .util import warning
+from .util import is_ipaddress, warning
 
 NO_PLAYER_STATE_IDS = [DASHCAST_APP_ID]
 DEVICES_WITH_TWO_MODEL_NAMES = {"Eureka Dongle": "Chromecast"}
@@ -69,20 +69,27 @@ def get_chromecast_with_ip(device_ip, port=DEFAULT_PORT):
         return None
 
 
-def get_cast(device_name=None):
+def get_cast(device=None):
     cast = None
-    cache = Cache()
-    cc_ip, cc_port = cache.get_data(device_name)
 
-    if cc_ip:
-        cast = get_chromecast_with_ip(cc_ip, cc_port)
-    if not cast:
-        cast = get_chromecast(device_name)
+    if device and is_ipaddress(device):
+        cast = get_chromecast_with_ip(device, DEFAULT_PORT)
         if not cast:
-            msg = 'Specified device "%s" not found' % device_name if device_name else "No devices found"
+            msg = "No device found at {}".format(device)
             raise CastError(msg)
+    else:
+        cache = Cache()
+        cc_ip, cc_port = cache.get_data(device)
 
-    cache.set_data(cast.name, cast.host, cast.port)
+        if cc_ip:
+            cast = get_chromecast_with_ip(cc_ip, cc_port)
+        if not cast:
+            cast = get_chromecast(device)
+            if not cast:
+                msg = 'Specified device "{}" not found'.format(device) if device else "No devices found"
+                raise CastError(msg)
+        cache.set_data(cast.name, cast.host, cast.port)
+
     cast.wait()
     return cast
 

--- a/catt/util.py
+++ b/catt/util.py
@@ -92,3 +92,12 @@ def get_local_ip(host):
                 return aip
             else:
                 continue
+
+
+def is_ipaddress(device):
+    try:
+        ipaddress.ip_address(device)
+    except ValueError:
+        return False
+    else:
+        return True

--- a/realcc_tests/test_procedure.py
+++ b/realcc_tests/test_procedure.py
@@ -202,10 +202,9 @@ AUDIO_ONLY_TESTS = [
     ),
     CattTest(
         'cast "http" format audio content from mixcloud (testing format hack)',
-        ["cast", "https://www.mixcloud.com/robert-toombs/tbt-2/"],
-        sleep=20,
+        ["cast", "https://www.mixcloud.com/Jazzmo/in-the-zone-march-2019-guidos-lounge-cafe/"],
         substring=True,
-        check_data=("content_id", "/c/m4a/64/7/3/0/1/774c-fb1a-45e9-a913-cb9e0eae9f98.m4a?sig=LGG0WHTLkXUAuoOVsdcbcA"),
+        check_data=("content_id", "/c/m4a/64/b/2/c/2/0d0c-d480-4c6a-9a9f-f485bd73bc45.m4a?sig=d65siY8itREY5iOVdGwC8w"),
     ),
     CattTest(
         'cast "wav" format audio content from bandcamp (testing format hack)',

--- a/tests/test_catt.py
+++ b/tests/test_catt.py
@@ -23,9 +23,9 @@ class TestThings(unittest.TestCase):
         self.assertEqual(stream.extractor, "youtube")
 
     def test_stream_info_other_video(self):
-        stream = StreamInfo("https://clips.twitch.tv/CloudyEnticingChickpeaCeilingCat")
+        stream = StreamInfo("https://www.twitch.tv/buddha/clip/OutstandingSquareMallardBudStar")
         self.assertIn("https://", stream.video_url)
-        self.assertEqual(stream.video_id, "304482431")
+        self.assertEqual(stream.video_id, "471296669")
         self.assertTrue(stream.is_remote_file)
         self.assertEqual(stream.extractor, "twitch")
 


### PR DESCRIPTION
Howdy! :cowboy_hat_face: 

This won't work with audio device groups, as the "group leader" is on a different port.
It should be easy to add a `--port` option. I'll implement that as soon as I get my hands on another cc audio, so I can test.

fixes #196