### PR TITLE
fix: Adapt write_config to "new" get_chromecast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Features
 
+* Add ability to use subtitles with remote content (#207) [theychx]
+
 * Add ability to use ip-address as device argument  (#197) [theychx]
 
 ### Fixes

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -106,8 +106,8 @@ def cli(ctx, delete_cache, device):
 @click.pass_obj
 def write_config(settings):
     if settings.get("device"):
-        # This is so we fail if the specified Chromecast cannot be found.
-        get_chromecast(settings["device"])
+        if not get_chromecast(settings["device"]):
+            raise CliError("Specified device not found")
         writeconfig(settings)
     else:
         raise CliError("No device specified")


### PR DESCRIPTION
:face_with_head_bandage: I completely missed this one.
Ever since I did the api work, `get_chromecast` no longer throws anything, if supplied with name of non-existent cc, which we have relied on in `write_config`. But fixed now...