### PR TITLE
fix: Only serve files forever if it is necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## Unreleased
+## v0.10.0 (2019-08-19)
 
 ### Features
 

--- a/catt/http_server.py
+++ b/catt/http_server.py
@@ -42,7 +42,7 @@ def parse_byte_range(byte_range):
     return first, last
 
 
-def serve_file(filename, address="", port=45114, content_type=None):
+def serve_file(filename, address="", port=45114, content_type=None, single_req=False):
     class FileHandler(BaseHTTPRequestHandler):
         def format_size(self, size):
             for size_unity in ["B", "KB", "MB", "GB", "TB"]:
@@ -108,5 +108,8 @@ def serve_file(filename, address="", port=45114, content_type=None):
     stats = mediapath.stat()
 
     httpd = socketserver.TCPServer((address, port), FileHandler)
-    httpd.serve_forever()
+    if single_req:
+        httpd.handle_request()
+    else:
+        httpd.serve_forever()
     httpd.server_close()

--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -120,6 +120,11 @@ class StreamInfo:
             return None
 
     @property
+    def guessed_content_category(self):
+        content_type = self.guessed_content_type
+        return content_type.split("/")[0] if content_type else None
+
+    @property
     def playlist_length(self):
         return len(self._entries) if self.is_playlist else None
 

--- a/realcc_tests/test_procedure.py
+++ b/realcc_tests/test_procedure.py
@@ -114,18 +114,20 @@ class CattTest:
 
 DEFAULT_CTRL_TESTS = [
     CattTest(
-        "cast h264 1280x720 / aac content from twitch.tv",
-        ["cast", "https://clips.twitch.tv/CloudyEnticingChickpeaCeilingCat"],
-        check_data=("content_id", "https://clips-media-assets2.twitch.tv/AT-cm%7C304482431.mp4"),
+        "cast h264 1920x1080 / aac content from dailymotion",
+        ["cast", "http://www.dailymotion.com/video/x6fotne"],
+        substring=True,
+        check_data=("content_id", "/H264-1920x1080/video/x6fotne.mp4"),
     ),
     CattTest("set volume to 50", ["volume", "50"], sleep=2, check_data=("volume_level", 0.5)),
     CattTest("set volume to 100", ["volume", "100"], sleep=2, check_data=("volume_level", 1.0)),
     CattTest("lower volume by 50 ", ["volumedown", "50"], sleep=2, check_data=("volume_level", 0.5)),
     CattTest("raise volume by 50", ["volumeup", "50"], sleep=2, check_data=("volume_level", 1.0)),
     CattTest(
-        "cast h264 640x360 / aac content from twitch.tv",
-        ["cast", "-y", "format=360", "https://clips.twitch.tv/CloudyEnticingChickpeaCeilingCat"],
-        check_data=("content_id", "https://clips-media-assets2.twitch.tv/AT-cm%7C304482431-360.mp4"),
+        "cast h264 320x240 / aac content from dailymotion",
+        ["cast", "-y", "format=http-240", "http://www.dailymotion.com/video/x6fotne"],
+        substring=True,
+        check_data=("content_id", "/H264-320x240/video/x6fotne.mp4"),
     ),
     CattTest(
         "cast h264 1280x720 / aac content from youtube using default controller",


### PR DESCRIPTION
:art: 
Server threads now die after having served an image or subtitles file once, so we only block the shell when strictly necessary.