### PR TITLE
Cache zeroconf device info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Fixes
 
+* Add socket based fallback approach in get_local_ip. [Stavros Korokithakis]
+
 * Add socket based fallback approach in get_local_ip. [theychx]
 
 * Fix namespace related crash when using DashCast. [Stavros Korokithakis]

--- a/catt/api.py
+++ b/catt/api.py
@@ -1,5 +1,6 @@
-from .controllers import get_app, get_chromecast, get_chromecast_with_ip, get_chromecasts, get_controller, get_stream
+from .controllers import get_app, get_chromecast, get_chromecast_with_ip, get_chromecasts, get_controller
 from .error import APIError, CastError
+from .stream_info import StreamInfo
 
 
 def discover() -> list:
@@ -69,7 +70,7 @@ class CattDevice:
         """
 
         if resolve:
-            stream = get_stream(url)
+            stream = StreamInfo(url)
             url = stream.video_url
         self.controller.prep_app()
         self.controller.play_media_url(url)

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -20,7 +20,6 @@ from .stream_info import StreamInfo
 from .util import is_ipaddress, warning
 
 NO_PLAYER_STATE_IDS = [DASHCAST_APP_ID]
-DEVICES_WITH_TWO_MODEL_NAMES = {"Eureka Dongle": "Chromecast"}
 DEFAULT_PORT = 8009
 VALID_STATE_EVENTS = ["UNKNOWN", "IDLE", "BUFFERING", "PLAYING", "PAUSED"]
 
@@ -75,8 +74,9 @@ def get_cast(device=None):
 
     :param device: Can be an ip-address or a name.
     :type device: str
-    :returns: Chromecast object for use in a CastController.
-    :rtype: pychromecast.Chromecast
+    :returns: Chromecast object for use in a CastController,
+              and CCInfo object for use in setup_cast and StreamInfo
+    :rtype: (pychromecast.Chromecast, CCInfo)
     """
 
     cast = None
@@ -86,30 +86,23 @@ def get_cast(device=None):
         if not cast:
             msg = "No device found at {}".format(device)
             raise CastError(msg)
+        cc_info = CCInfo(cast.host, cast.port, None, None, cast.cast_type)
     else:
         cache = Cache()
-        cc_ip, cc_port = cache.get_data(device)
+        cc_info = cache.get_data(device)
 
-        if cc_ip:
-            cast = get_chromecast_with_ip(cc_ip, cc_port)
+        if cc_info:
+            cast = get_chromecast_with_ip(cc_info.ip, cc_info.port)
         if not cast:
             cast = get_chromecast(device)
             if not cast:
                 msg = 'Specified device "{}" not found'.format(device) if device else "No devices found"
                 raise CastError(msg)
-        cache.set_data(cast.name, cast.host, cast.port)
+            cc_info = CCInfo(cast.host, cast.port, cast.device.manufacturer, cast.model_name, cast.cast_type)
+            cache.set_data(cast.name, cc_info)
 
     cast.wait()
-    return cast
-
-
-def get_stream(url, device_info=None, host=None, ytdl_options=None):
-    cc_info = cast_type = None
-    if device_info:
-        model_name = DEVICES_WITH_TWO_MODEL_NAMES.get(device_info.model_name, device_info.model_name)
-        cc_info = (device_info.manufacturer, model_name)
-        cast_type = device_info.cast_type
-    return StreamInfo(url, host=host, model=cc_info, device_type=cast_type, ytdl_options=ytdl_options)
+    return (cast, cc_info)
 
 
 def get_app(id_or_name, cast_type=None, strict=False, show_warning=False):
@@ -147,11 +140,9 @@ def get_controller(cast, app, action=None, prep=None):
 
 
 def setup_cast(device_name, video_url=None, controller=None, ytdl_options=None, action=None, prep=None):
-    cast = get_cast(device_name)
-    cast_type = cast.cast_type
-    stream = (
-        get_stream(video_url, device_info=cast.device, host=cast.host, ytdl_options=ytdl_options) if video_url else None
-    )
+    cast, cc_info = get_cast(device_name)
+    cast_type = cc_info.cast_type
+    stream = StreamInfo(video_url, device_info=cc_info, ytdl_options=ytdl_options) if video_url else None
 
     if controller:
         app = get_app(controller, cast_type, strict=True)
@@ -206,6 +197,19 @@ class CattStore:
             pass
 
 
+class CCInfo:
+    def __init__(self, ip, port, manufacturer, model_name, cast_type):
+        self.ip = ip
+        self.port = port
+        self.manufacturer = manufacturer
+        self.model_name = model_name
+        self.cast_type = cast_type
+
+    @property
+    def all_info(self):
+        return self.__dict__
+
+
 class Cache(CattStore):
     def __init__(self):
         vhash = hashlib.sha1(__version__.encode()).hexdigest()[:8]
@@ -215,32 +219,33 @@ class Cache(CattStore):
 
         if not self.store_path.is_file():
             devices = get_chromecasts()
-            cache_data = {d.name: self._create_device_entry(d.host, d.port) for d in devices}
+            cache_data = {
+                d.name: CCInfo(d.host, d.port, d.device.manufacturer, d.model_name, d.cast_type).all_info
+                for d in devices
+            }
             self._write_store(cache_data)
-
-    def _create_device_entry(self, ip, port):
-        device_data = {"ip": ip}
-        if port != DEFAULT_PORT:
-            device_data["group_port"] = port
-        return device_data
 
     def get_data(self, name: str):  # type: ignore
         data = self._read_store()
         # In the case that cache has been initialized with no cc's on the
         # network, we need to ensure auto-discovery.
         if not data:
-            return (None, None)
+            return None
         if name:
             fetched = data.get(name)
         else:
             # When the user does not specify a device, we need to make an attempt
             # to consistently return the same IP, thus the alphabetical sorting.
             fetched = data[min(data, key=str)]
-        return (fetched["ip"], fetched.get("group_port", 0)) if fetched else (None, None)
+        return (
+            CCInfo(fetched["ip"], fetched["port"], fetched["manufacturer"], fetched["model_name"], fetched["cast_type"])
+            if fetched
+            else None
+        )
 
-    def set_data(self, name: str, ip: str, port: int) -> None:  # type: ignore
+    def set_data(self, name: str, device_entry: CCInfo) -> None:  # type: ignore
         data = self._read_store()
-        data[name] = self._create_device_entry(ip, port)
+        data[name] = device_entry.all_info
         self._write_store(data)
 
 

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -237,11 +237,7 @@ class Cache(CattStore):
             # When the user does not specify a device, we need to make an attempt
             # to consistently return the same IP, thus the alphabetical sorting.
             fetched = data[min(data, key=str)]
-        return (
-            CCInfo(fetched["ip"], fetched["port"], fetched["manufacturer"], fetched["model_name"], fetched["cast_type"])
-            if fetched
-            else None
-        )
+        return CCInfo(**fetched) if fetched else None
 
     def set_data(self, name: str, device_entry: CCInfo) -> None:  # type: ignore
         data = self._read_store()

--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -7,7 +7,7 @@ from .error import ExtractionError, FormatError, PlaylistError
 from .util import get_local_ip, guess_mime
 
 AUDIO_DEVICE_TYPES = ["audio", "group"]
-ULTRA_MODELS = [("Xiaomi", "MIBOX3"), ("Google Inc.", "Chromecast Ultra")]
+ULTRA_MODELS = [("Xiaomi", "MIBOX3"), ("Unknown manufacturer", "Chromecast Ultra")]
 
 BEST_MAX_2K = "best[width <=? 1920][height <=? 1080]"
 BEST_MAX_4K = "best[width <=? 3840][height <=? 2160]"

--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -7,6 +7,10 @@ from .error import ExtractionError, FormatError, PlaylistError
 from .util import get_local_ip, guess_mime
 
 AUDIO_DEVICE_TYPES = ["audio", "group"]
+# The manufacturer field is currently unavailable for Google products.
+# It is still accessible via DIAL for some devices, but this resource
+# is currently not being used by PyChromecast.
+# See https://github.com/balloob/pychromecast/pull/197
 ULTRA_MODELS = [("Xiaomi", "MIBOX3"), ("Unknown manufacturer", "Chromecast Ultra")]
 
 BEST_MAX_2K = "best[width <=? 1920][height <=? 1080]"

--- a/tests/test_catt.py
+++ b/tests/test_catt.py
@@ -3,7 +3,7 @@
 
 import unittest
 
-from catt.controllers import Cache
+from catt.controllers import Cache, CCInfo
 from catt.stream_info import StreamInfo
 
 
@@ -31,12 +31,21 @@ class TestThings(unittest.TestCase):
 
     def test_cache(self):
         cache = Cache()
-        cache.set_data("name", "ip", "port")
-        self.assertEqual(cache.get_data("name"), ("ip", "port"))
+        cache.set_data("name", CCInfo("192.168.0.6", 8009, "Fake Factory Inc.", "Fakecast", "fake"))
+        self.assertEqual(
+            cache.get_data("name").all_info,
+            {
+                "ip": "192.168.0.6",
+                "port": 8009,
+                "manufacturer": "Fake Factory Inc.",
+                "model_name": "Fakecast",
+                "cast_type": "fake",
+            },
+        )
 
         cache.clear()
         cache = Cache()
-        self.assertEqual(cache.get_data("name"), (None, None))
+        self.assertEqual(cache.get_data("name"), None)
         cache.clear()
 
 


### PR DESCRIPTION
Howdy
For some time now, Google devices have stopped providing manufacturer/model_name info through DIAL, breaking our device type detection stuff in `StreamInfo`. So I've implemented a change to our caching, so we cache all the info we need from zeroconf. This work also turned out make some code a bit leaner.

PS: Your changelog thingy is indeed out of control :smile: 