### PR TITLE
Update PyChromecast requirement

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,3 +10,4 @@ isort
 mypy
 gitchangelog
 pystache
+PyYAML==5.2;python_version<"3.5"

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open("README.rst") as readme_file:
 
 requirements = [
     "youtube-dl>=2019.01.24",
-    "PyChromecast>=2.4.0",
+    "PyChromecast>=4.1.1",
     "Click>=5.0",
     "ifaddr>=0.1.4",
     "requests>=2.18.4",


### PR DESCRIPTION
..to fix zeroconf issues

As it turns out, the problem was with `PyChromecast`s way of utilizing `zeroconf`, and not with `zeroconf` itself. Fixed in `4.1.1`.

Please make a release, so new users are not affected by this.

fixes #226
:cowboy_hat_face: 