### PR TITLE
Fix filename display

### DIFF
--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -91,9 +91,9 @@ class StreamInfo:
     @property
     def video_title(self):
         if self.is_local_file:
-            return Path(self._local_file).name
+            return Path(self._local_file).stem
         elif self._is_direct_link:
-            return self._preinfo["webpage_url_basename"].split(".")[0]
+            return Path(self._preinfo["webpage_url_basename"]).stem
         elif self.is_remote_file or self.is_playlist_with_active_entry:
             return self._info["title"]
         else:

--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -119,7 +119,7 @@ class StreamInfo:
     @property
     def guessed_content_type(self):
         if self.is_local_file:
-            return guess_mime(self.video_title)
+            return guess_mime(Path(self._local_file).name)
         elif self._is_direct_link:
             return guess_mime(self._info["webpage_url_basename"])
         else:


### PR DESCRIPTION
..when casting local files or direct urls.

Previous code never worked as I intended it, which was to show bare filename sans file-extension.