### PR TITLE
Create parent directories if config dir doesn't exist (fixes #251)

### DIFF
--- a/catt/cli.py
+++ b/catt/cli.py
@@ -532,7 +532,7 @@ def get_device_from_settings(settings):
 
 def writeconfig(config):
     try:
-        CONFIG_DIR.mkdir()
+        CONFIG_DIR.mkdir(parents=True)
     except FileExistsError:
         pass
 


### PR DESCRIPTION
This fixes #251, though I am still confused as to why the config dir might not exist.