### PR TITLE
feat: Add remote-only subtitles to the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
 # Changelog
 
 
-## v0.11.3 (2020-07-18)
+## Unreleased
 
 ### Features
 
 * Add subtitles to the API. [Stavros Korokithakis]
+
+### Fixes
+
+* Recognize the .jpeg suffix as a jpeg file. [Stavros Korokithakis]
+
+
+## v0.11.3 (2020-07-18)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## Unreleased
+
+### Fixes
+
+* Create parent directories if config dir doesn't exist (fixes #251) (#252) [Stavros Korokithakis]
+
+
 ## v0.11.0 (2020-03-01)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## Unreleased
 
+### Features
+
+* Add subtitles to the API. [Stavros Korokithakis]
+
 ### Fixes
 
 * Create parent directories if config dir doesn't exist (fixes #251) (#252) [Stavros Korokithakis]

--- a/catt/api.py
+++ b/catt/api.py
@@ -76,7 +76,8 @@ class CattDevice:
                              If this is not set, it is assumed that the url points directly to the stream.
         :param block:        Block until playback has stopped,
                              either by end of content being reached, or by interruption.
-        :param subtitle_url: A URL to a subtitle file to use when playing.
+        :param subtitle_url: A URL to a subtitle file to use when playing. Make sure CORS headers are correct on the
+                             server when using this, and that the subtitles are in a suitable format.
         """
 
         if resolve:

--- a/catt/api.py
+++ b/catt/api.py
@@ -58,22 +58,23 @@ class CattDevice:
             self._create_controller()
         return self._cast_controller
 
-    def play_url(self, url: str, resolve: bool = False, block: bool = False) -> None:
+    def play_url(self, url: str, resolve: bool = False, block: bool = False, subtitle_url: str = None) -> None:
         """
         Initiate playback of content.
 
-        :param url: Network location of content.
-        :param resolve: Try to resolve location of content stream with Youtube-dl.
-                        If this is not set, it is assumed that the url points directly to the stream.
-        :param block: Block until playback has stopped,
-                      either by end of content being reached, or by interruption.
+        :param url:          Network location of content.
+        :param resolve:      Try to resolve location of content stream with Youtube-dl.
+                             If this is not set, it is assumed that the url points directly to the stream.
+        :param block:        Block until playback has stopped,
+                             either by end of content being reached, or by interruption.
+        :param subtitle_url: A URL to a subtitle file to use when playing.
         """
 
         if resolve:
             stream = StreamInfo(url)
             url = stream.video_url
         self.controller.prep_app()
-        self.controller.play_media_url(url)
+        self.controller.play_media_url(url, subtitles=subtitle_url)
 
         if self.controller.wait_for(["PLAYING"], timeout=10):
             if block:

--- a/catt/util.py
+++ b/catt/util.py
@@ -51,6 +51,7 @@ def guess_mime(path):
         ".mkv": "video/x-matroska",
         ".bmp": "image/bmp",
         ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
         ".gif": "image/gif",
         ".png": "image/png",
         ".webp": "image/web",


### PR DESCRIPTION
For your consideration, a subtitle parameter to the API call.

I'm not sure whether it should be called `subtitle_url`, though, I'm not sure if it has to be a URL or if it can be a path.