### PR TITLE
fix: Force pychromecast 7, update to new api

### DIFF
--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -41,7 +41,7 @@ APPS = [
 
 
 def get_chromecasts():
-    devices = pychromecast.get_chromecasts()
+    devices, _browser = pychromecast.get_chromecasts()
     devices.sort(key=lambda cc: cc.name)
     return devices
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open("README.rst") as readme_file:
 
 requirements = [
     "youtube-dl>=2020.6.6",
-    "PyChromecast>=6.0.0",
+    "PyChromecast>=7.0.0",
     "Click>=7.1.2",
     "ifaddr>=0.1.7",
     "requests>=2.23.0",


### PR DESCRIPTION
Pychromecast 7 has a breaking change, with the return type of the
get_chromecasts function changing to also return a browser.

I ran black over this file but for me it changes a lot more of the formatting - happy to do that but wanted to check (and also at least isolate the actual change made to make it clearer). Also running tests locally seemed to be trying to do things to my actual chromecasts (?) so I thought I'd leave that for travis.

Deals with issue #271 