### PR TITLE
Fix byte range assert to test for 'is not None'

### DIFF
--- a/catt/http_server.py
+++ b/catt/http_server.py
@@ -46,7 +46,7 @@ def parse_byte_range(byte_range: str) -> Tuple[Optional[int], Optional[int]]:
         raise ValueError("Invalid byte range {}".format(byte_range))
 
     first, last = [int(x) if x else None for x in match.groups()]
-    assert first
+    assert first is not None
     if last and last < first:
         raise ValueError("Invalid byte range {}".format(byte_range))
     return first, last


### PR DESCRIPTION
Fix byte range assert to test for 'is not None', to avoid breaking on ranges starting zero
Properly fixes #279 