### PR TITLE
fix: Increase timeout for the Chromecast to connect to the HTTP server

### DIFF
--- a/catt/cli.py
+++ b/catt/cli.py
@@ -31,6 +31,8 @@ CONFIG_DIR = Path(click.get_app_dir("catt"))
 CONFIG_PATH = Path(CONFIG_DIR, "catt.cfg")
 STATE_PATH = Path(CONFIG_DIR, "state.json")
 
+WAIT_PLAY_TIMEOUT = 30
+
 
 class CattTimeParamType(click.ParamType):
     def convert(self, value, param, ctx):
@@ -230,7 +232,7 @@ def cast(settings, video_url, subtitles, force_default, random_play, no_subs, no
     if stream.is_local_file or subs:
         click.echo("Serving local file(s).")
     if not media_is_image and (stream.is_local_file or block):
-        if not cst.wait_for(["PLAYING"], timeout=10):
+        if not cst.wait_for(["PLAYING"], timeout=WAIT_PLAY_TIMEOUT):
             raise CliError("Playback of {} file has failed".format(local_or_remote))
         cst.wait_for(["UNKNOWN", "IDLE"])
     elif (stream.is_local_file and media_is_image) or subs:


### PR DESCRIPTION
The current 10 second wait isn't long enough on slow networks (like my wifi network at home!). Let's wait 30 seconds instead.

Fixes #294.

I was unable to reproduce the issue again with the 10 second wait (typical!), but I was able to repro by setting the timeout *lower*.

Thanks!