### PR TITLE
Add catt/__main__.py to enable 'python -m catt'

### DIFF
--- a/catt/__main__.py
+++ b/catt/__main__.py
@@ -1,0 +1,2 @@
+from .cli import main
+main()


### PR DESCRIPTION
Thanks for the tool, used it for the first time minutes ago and worked flawlessly.

Immediately had the suggestion to allow `$ python -m catt ...` in case the entry point isn't installed properly (ie pyenv)