### PR TITLE
Hopefully fix CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## Unreleased
+
+### Fixes
+
+* Don't do discovery dance when checking ip validity (#309) [theychx]
+
+
 ## v0.12.0 (2020-10-28)
 
 ### Features

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open("README.rst") as readme_file:
 requirements = [
     "youtube-dl>=2020.9.20",
     "PyChromecast>=7.5.0",
-    "Click>=7.1.2",
+    "Click>=7.1.2,<8",
     "ifaddr>=0.1.7",
     "requests>=2.23.0",
     'typing;python_version<"3.5"',

--- a/tests/test_catt.py
+++ b/tests/test_catt.py
@@ -39,7 +39,8 @@ class TestThings(unittest.TestCase):
     @ignore_tmr_failure
     def test_stream_info_youtube_playlist(self):
         stream = StreamInfo(
-            "https://www.youtube.com/playlist?list=PL9Z0stL3aRykWNoVQW96JFIkelka_93Sc", throw_ytdl_dl_errs=True
+            "https://www.youtube.com/playlist?list=PL9Z0stL3aRykWNoVQW96JFIkelka_93Sc",
+            throw_ytdl_dl_errs=True,
         )
         self.assertIsNone(stream.video_url)
         self.assertEqual(stream.playlist_id, "PL9Z0stL3aRykWNoVQW96JFIkelka_93Sc")
@@ -47,9 +48,9 @@ class TestThings(unittest.TestCase):
         self.assertEqual(stream.extractor, "youtube")
 
     def test_stream_info_other_video(self):
-        stream = StreamInfo("https://www.twitch.tv/forsen/clip/TangibleSpicyDogeTooSpicy")
+        stream = StreamInfo("https://www.twitch.tv/twitch/clip/MistySoftPenguinKappaPride")
         self.assertIn("https://", stream.video_url)
-        self.assertEqual(stream.video_id, "900171331")
+        self.assertEqual(stream.video_id, "944456168")
         self.assertTrue(stream.is_remote_file)
         self.assertEqual(stream.extractor, "twitch")
 


### PR DESCRIPTION
CI installs Click 8, which doesn't work in 3.5. This PR limits the dependencies so we only use 7.x.