### PR TITLE
fix docker example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ regularly to keep them all working.
 
 You can also run ``catt`` in Docker, if you prefer::
 
-    docker run -i -t python:3.7 /bin/bash -c "pip install catt; catt cast 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'"
+    docker run --net=host --rm -it python:3.7 /bin/bash -c "pip install catt; catt cast 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'"
 
 
 Configuration file


### PR DESCRIPTION
Given docker example would not work, because container is put in its own network, where are no devices. Forcing docker to join host network allows it to see devices. Also `--rm` added, so that example will be deleted as soon as it is executed.