### PR TITLE
Fixed casing issue with device names (#375)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## Unreleased
+## v0.12.5 (2021-12-19)
 
 ### Fixes
 

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -111,8 +111,9 @@ def process_device(device_desc, aliases):
         return device_desc
     else:
         if device_desc:
-            device_desc = device_desc.lower()
-        return aliases.get(device_desc, device_desc)
+            return aliases.get(device_desc.lower(), device_desc)
+        else:
+            return device_desc
 
 
 def fail_if_no_ip(ipaddr):


### PR DESCRIPTION
This fix allows device names to be specified in mixed case, but keeps aliases case-insensitive (issue #375). I didn't add any automated tests since they would require specific Chromecast device names to really work, but I did some manual testing:

catt.cfg:
```
[aliases]
test1 = Bedroom TV
TEST2 = Chromecast_2
```

Tests:
```
catt -d "Bedroom TV" status
Volume: 100
catt -d test1 status
Volume: 100
catt -d Test1 status
Volume: 100
catt -d test2 status
Error: Specified device "Chromecast_2" not found.
catt -d Test2 status
Error: Specified device "Chromecast_2" not found.
catt -d "Bedroom TV" set_alias Test3
# no output
catt -d "Bedroom TV" set_default
# no output
catt -d TEST3 status
Volume: 100
```

catt.cfg after:
```
[aliases]
test2 = Chromecast_2
test3 = Bedroom TV

[options]
device = Bedroom TV
```