### PR TITLE
Catching the ImportError on systems running Python versions older than 3.8

### DIFF
--- a/catt/cli.py
+++ b/catt/cli.py
@@ -3,7 +3,11 @@ import configparser
 import random
 import sys
 import time
-from importlib.metadata import version
+try:
+    from importlib.metadata import version
+except ImportError:
+    # We're running a Python < 3.8
+    from importlib_metadata import version
 from pathlib import Path
 from threading import Thread
 from urllib.parse import urlparse


### PR DESCRIPTION
The importlib.metadata used to live as importlib_metadata, this try…except will make catt runnable on older installations