### PR TITLE
Fix youtube playlist issues

### DIFF
--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -166,7 +166,7 @@ class StreamInfo:
 
     def _get_stream_preinfo(self, video_url):
         try:
-            return self._ydl.sanitize_info(self._ydl.extract_info(video_url, process=False))
+            return self._ydl.extract_info(video_url, process=False)
         except yt_dlp.utils.DownloadError:
             # We sometimes get CI failures when testing with YouTube videos,
             # as YouTube throttles our connections intermittently. We evaluated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ click = ">=7.1.2"
 ifaddr = ">=0.1.7"
 pychromecast = ">=12.1.4, <13"
 requests = ">=2.23.0"
-yt-dlp = ">=2021.12.1"
+yt-dlp = ">=2022.6.22.1"
 
 [tool.poetry.dev-dependencies]
 coverage = "*"

--- a/realcc_tests/test_procedure.py
+++ b/realcc_tests/test_procedure.py
@@ -171,12 +171,12 @@ DEFAULT_CTRL_TESTS = [
 YOUTUBE_CTRL_TESTS = [
     CattTest(
         "cast video from youtube",
-        ["cast", "https://www.youtube.com/watch?v=Rl4GiVtnLE4"],
-        check_data=("content_id", "Rl4GiVtnLE4"),
+        ["cast", "https://www.youtube.com/watch?v=mwPSIb3kt_4"],
+        check_data=("content_id", "mwPSIb3kt_4"),
     ),
     CattTest(
         "cast video from youtube, start at 2:02",
-        ["cast", "-t", "2:02", "https://www.youtube.com/watch?v=Rl4GiVtnLE4"],
+        ["cast", "-t", "2:02", "https://www.youtube.com/watch?v=mwPSIb3kt_4"],
         sleep=5,
         time_test=True,
         check_data=("current_time", "122"),
@@ -234,7 +234,7 @@ AUDIO_ONLY_TESTS = [
         'cast "wav" format audio content from bandcamp (testing format hack)',
         ["cast", "https://physicallysick.bandcamp.com/track/freak-is-out"],
         substring=True,
-        check_data=("content_id", "track?enc=wav"),
+        check_data=("content_id", "track?enc=flac"),
     ),
 ]
 


### PR DESCRIPTION
Originally reported in #376.
Casting of direct media urls seem to work again, so I updated the `yt-dlp` requirement.

fixes #367