### PR TITLE
Fix discovery function

### DIFF
--- a/catt/api.py
+++ b/catt/api.py
@@ -164,4 +164,4 @@ class CattDevice:
 def discover() -> List[CattDevice]:
     """Perform discovery of devices present on local network, and return result."""
 
-    return [CattDevice(ip_addr=c.ip) for c in get_casts()]
+    return [CattDevice(ip_addr=c.socket_client.host) for c in get_casts()]


### PR DESCRIPTION
The path to get the ip from pychromecast is now c.socket_client.host