### PR TITLE
Fix the 10 minutes timeout issue

### DIFF
--- a/catt/cli.py
+++ b/catt/cli.py
@@ -315,16 +315,22 @@ def cast(
 
 @cli.command("cast_site", short_help="Cast any website to a Chromecast.")
 @click.argument("url", callback=process_url)
+@click.option(
+    "-i",
+    "--iframe",
+    is_flag=True,
+    help="Load website into an iframe to avoid timeout (requires HTTPS).",
+)
 @click.pass_obj
-def cast_site(settings, url):
+def cast_site(settings, url, iframe):
     cst = setup_cast(
         settings["selected_device"],
         controller="dashcast",
         action="load_url",
         prep="app",
     )
-    click.echo('Casting {} on "{}"...'.format(url, cst.cc_name))
-    cst.load_url(url)
+    click.echo('Casting {} on "{}" (iframe={})...'.format(url, cst.cc_name, iframe))
+    cst.load_url(url, force=not iframe)
 
 
 @cli.command(short_help="Add a video to the queue (YouTube only).")

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -7,7 +7,6 @@ from typing import Optional
 
 import pychromecast
 from pychromecast.config import APP_BACKDROP as BACKDROP_APP_ID
-from pychromecast.config import APP_DASHCAST as DASHCAST_APP_ID
 from pychromecast.config import APP_MEDIA_RECEIVER as MEDIA_RECEIVER_APP_ID
 from pychromecast.config import APP_YOUTUBE as YOUTUBE_APP_ID
 from pychromecast.controllers.dashcast import DashCastController as PyChromecastDashCastController
@@ -25,6 +24,9 @@ from .util import echo_warning
 GOOGLE_MEDIA_NAMESPACE = "urn:x-cast:com.google.cast.media"
 VALID_STATE_EVENTS = ["UNKNOWN", "IDLE", "BUFFERING", "PLAYING", "PAUSED"]
 CLOUD_APP_ID = "38579375"
+
+DASHCAST_NAMESPACE = "urn:x-cast:es.offd.dashcast"
+DASHCAST_APP_ID = "5C517DAC"
 
 
 class App:
@@ -496,11 +498,11 @@ class DefaultCastController(CastController, MediaControllerMixin, PlaybackBaseMi
 
 class DashCastController(CastController):
     def __init__(self, cast, app, prep=None):
-        self._controller = PyChromecastDashCastController()
+        self._controller = PyChromecastDashCastController(appNamespace=DASHCAST_NAMESPACE, appId=DASHCAST_APP_ID)
         super(DashCastController, self).__init__(cast, app, prep=prep)
 
-    def load_url(self, url, **kwargs):
-        self._controller.load_url(url, force=True)
+    def load_url(self, url, force=True, **kwargs):
+        self._controller.load_url(url, force=force)
 
     def prep_app(self):
         """Make sure desired chromecast app is running."""


### PR DESCRIPTION
I have forked DashCast to implement a fix for the timeout problem:

https://github.com/swiergot/dashcast

It is registered at Google under ID 5C517DAC.

This pull request a) switches to this new DashCast version and b) adds a new option to cast_site to enable the fix (for backward compatibility the old behaviour remains the default).

Please note that due to security constraints the new method requires the casted website to be served over HTTPS.