### PR TITLE
doc: Document macOS config path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ You can also run `catt` in Docker, if you prefer:
 ### Configuration file
 
 CATT can utilize a config-file stored at `~/.config/catt/catt.cfg`
-(`%APPDATA%\catt\catt.cfg` on Windows).
+(`%APPDATA%\catt\catt.cfg` on Windows, `~/Library/Application Support/catt/catt.cfg` on macOS).
 
 The format is as following:
 


### PR DESCRIPTION
This updates the README to document the config path as ~/Library/Application Support/catt/catt.cfg. It does not read from ~/.config/catt/catt.cfg on macOS.