### PR TITLE
Add volumemute command

### DIFF
--- a/catt/api.py
+++ b/catt/api.py
@@ -162,7 +162,7 @@ class CattDevice:
 
     def volumemute(self, muted: bool) -> None:
         """
-        Enable mute on supported devices. Added by @neurodiv-eric
+        Enable mute on supported devices.
 
         :param muted: Whether to mute the device. (valid values: true or false).
         """

--- a/catt/api.py
+++ b/catt/api.py
@@ -160,6 +160,15 @@ class CattDevice:
 
         self.controller.volumedown(delta)
 
+    def volumemute(self, muted: bool) -> None:
+        """
+        Enable mute on supported devices. Added by @neurodiv-eric
+
+        :param muted: Whether to mute the device. (valid values: true or false).
+        """
+
+        self.controller.volumemute(muted)
+
 
 def discover() -> List[CattDevice]:
     """Perform discovery of devices present on local network, and return result."""

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -460,6 +460,14 @@ def volumedown(settings, delta):
     cst.volumedown(delta / 100.0)
 
 
+@cli.command(short_help="Enable or disable mute on supported devices.")
+@click.argument("muted", type=click.BOOL, required=False, default=True, metavar="MUTED")
+@click.pass_obj
+def volumemute(settings, muted):
+    cst = setup_cast(settings["selected_device"])
+    cst.volumemute(muted)
+
+
 @cli.command(short_help="Show some information about the currently-playing video.")
 @click.pass_obj
 def status(settings):

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -378,6 +378,9 @@ class CastController:
     def volumedown(self, delta: float) -> None:
         self._cast.volume_down(delta)
 
+    def volumemute(self, muted: bool) -> None:
+        self._cast.set_volume_muted(muted)
+
     def kill(self, idle_only=False, force=False):
         """
         Kills current Chromecast session.

--- a/catt/util.py
+++ b/catt/util.py
@@ -39,7 +39,7 @@ def echo_status(status):
         click.echo("Volume: {}".format(status["volume_level"]))
 
     if status.get("volume_muted"):
-        click.echo("Volume Muted: {}".format(status["is_volume_muted"]))
+        click.echo("Volume muted: {}".format(status["is_volume_muted"]))
 
 
 def guess_mime(path):

--- a/catt/util.py
+++ b/catt/util.py
@@ -38,6 +38,9 @@ def echo_status(status):
     if status.get("volume_level"):
         click.echo("Volume: {}".format(status["volume_level"]))
 
+    if status.get("volume_muted"):
+        click.echo("Volume Muted: {}".format(status["is_volume_muted"]))
+
 
 def guess_mime(path):
     # source: https://developers.google.com/cast/docs/media

--- a/realcc_tests/test_procedure.py
+++ b/realcc_tests/test_procedure.py
@@ -122,6 +122,8 @@ DEFAULT_CTRL_TESTS = [
     CattTest("set volume to 100", ["volume", "100"], sleep=2, check_data=("volume_level", 1.0)),
     CattTest("lower volume by 50 ", ["volumedown", "50"], sleep=2, check_data=("volume_level", 0.5)),
     CattTest("raise volume by 50", ["volumeup", "50"], sleep=2, check_data=("volume_level", 1.0)),
+    CattTest("mute the media volume", ["volumemute", "True"], sleep=2, check_data=("is_volume_muted", True)),
+    CattTest("unmute the media volume", ["volumemute", "False"], sleep=2, check_data=("is_volume_muted", False)),
     CattTest(
         "cast h264 320x184 / aac content from dailymotion",
         ["cast", "-y", "format=http-240-1", "http://www.dailymotion.com/video/x6fotne"],


### PR DESCRIPTION
With this addition, CATT should now have the ability to toggle between mute states while automatically preserving the previous volume level. This function will also prevent a volume preview tone on some devices.

Example: `catt -d <DEVICE_OR_IP> volumemute <true | false>`
Note that the default value is `true`.

### Does this work for all devices?
_Not exactly._ I also have a Lenovo Smart Display. While that device mutes and unmutes as expected, it unfortunately still emits a volume tone.

I only have the two device models, so feedback on which brands are/are not working would be great. I suspect it to be the same as Home Assistant's `media_player.volume_mute` service.