### PR TITLE
fix: Update pychromecast requirement plus fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## Unreleased
+
+### Features
+
+* Add volumemute command (#427) [neurodiv-eric]
+
+
 ## v0.12.10 (2023-01-30)
 
 ### Features

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -315,7 +315,10 @@ class CastController:
 
     @property
     def cast_info(self):
-        cinfo = {"volume_level": str(int(round(self._cast.status.volume_level, 2) * 100))}
+        cinfo = {
+            "volume_level": str(int(round(self._cast.status.volume_level, 2) * 100)),
+            "volume_muted": self._cast.status.volume_muted
+        }
 
         if self._is_idle:
             return cinfo

--- a/catt/util.py
+++ b/catt/util.py
@@ -35,11 +35,8 @@ def echo_status(status):
     if status.get("player_state"):
         click.echo("State: {}".format(status["player_state"]))
 
-    if status.get("volume_level"):
-        click.echo("Volume: {}".format(status["volume_level"]))
-
-    if status.get("volume_muted"):
-        click.echo("Volume muted: {}".format(status["is_volume_muted"]))
+    click.echo("Volume: {}".format(status["volume_level"]))
+    click.echo("Volume muted: {}".format(status["volume_muted"]))
 
 
 def guess_mime(path):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,9 @@ catt = "catt.cli:main"
 python = ">=3.7"
 click = ">=7.1.2"
 ifaddr = ">=0.1.7"
-pychromecast = ">=12.1.4, <13"
+pychromecast = ">=13.0.7, <14"
 requests = ">=2.23.0"
-yt-dlp = ">=2022.6.22.1"
+yt-dlp = ">=2023.3.4"
 
 [tool.poetry.dev-dependencies]
 coverage = "*"

--- a/realcc_tests/test_procedure.py
+++ b/realcc_tests/test_procedure.py
@@ -122,8 +122,8 @@ DEFAULT_CTRL_TESTS = [
     CattTest("set volume to 100", ["volume", "100"], sleep=2, check_data=("volume_level", 1.0)),
     CattTest("lower volume by 50 ", ["volumedown", "50"], sleep=2, check_data=("volume_level", 0.5)),
     CattTest("raise volume by 50", ["volumeup", "50"], sleep=2, check_data=("volume_level", 1.0)),
-    CattTest("mute the media volume", ["volumemute", "True"], sleep=2, check_data=("is_volume_muted", True)),
-    CattTest("unmute the media volume", ["volumemute", "False"], sleep=2, check_data=("is_volume_muted", False)),
+    CattTest("mute the media volume", ["volumemute", "True"], sleep=2, check_data=("volume_muted", True)),
+    CattTest("unmute the media volume", ["volumemute", "False"], sleep=2, check_data=("volume_muted", False)),
     CattTest(
         "cast h264 320x184 / aac content from dailymotion",
         ["cast", "-y", "format=http-240-1", "http://www.dailymotion.com/video/x6fotne"],


### PR DESCRIPTION
I've done some tests, and everything seems fine with `pychromecast 13.0.7`.
I've had to make some minor fixes to the `volumemute` functionality in order to complete those tests.