### PR TITLE
fix: set explicit build-backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
 [tool]
 
 [tool.poetry]


### PR DESCRIPTION
The project seems to use poetry to manage its dependencies, and defining the build-system allows building it using the generic `build` frontend, which distros heavily rely on.

See https://github.com/python-poetry/poetry-core#usage.