### PR TITLE
chore: updated pychromecast dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ catt = "catt.cli:main"
 python = ">=3.7"
 click = ">=7.1.2"
 ifaddr = ">=0.1.7"
-pychromecast = ">=13.0.7, <14"
+pychromecast = ">=14.0.1, <15"
 requests = ">=2.23.0"
 yt-dlp = ">=2023.3.4"
 


### PR DESCRIPTION
Update pychromecast to 14.0.1

During my testing I found no issues, but I only cast the HA dashboard...
So nothing fancy.

