### PR TITLE
Make HACS-compatible (fixes #452)

### DIFF
--- a/custom_components/catt/__init__.py
+++ b/custom_components/catt/__init__.py
@@ -1,0 +1,18 @@
+# This file makes Home Assistant recognize this directory as an integration.
+# For CATT, which is primarily a CLI tool, this allows HACS to manage it.
+
+DOMAIN = "catt"
+
+async def async_setup(hass, config):
+    # Mark domain as loaded. CATT itself doesn't integrate deeply with Home Assistant's event loop
+    # or entity system in a typical way, so setup is minimal.
+    hass.data[DOMAIN] = {}
+    return True
+
+async def async_setup_entry(hass, entry):
+    # CATT does not use config entries.
+    return True
+
+async def async_unload_entry(hass, entry):
+    # CATT does not use config entries.
+    return True

--- a/custom_components/catt/manifest.json
+++ b/custom_components/catt/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "catt",
+  "name": "Cast All The Things",
+  "documentation": "https://github.com/skorokithakis/catt",
+  "issue_tracker": "https://github.com/skorokithakis/catt/issues",
+  "codeowners": ["@skorokithakis"],
+  "version": "0.12.0",
+  "iot_class": "local_polling",
+  "requirements": ["catt==0.12.0"]
+}

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,6 @@
+{
+  "name": "catt",
+  "content_in_root": true,
+  "filename": "catt",
+  "render_readme": true
+}


### PR DESCRIPTION
Add HACS compliance files for content_in_root

This commit introduces the necessary files and directory structure to make the 'catt' repository compatible with HACS (Home Assistant Community Store) using the 'content_in_root' approach.

Changes include:
- Added `hacs.json` to the repository root, configured with `content_in_root: true` and `filename: "catt"`.
- Created the `custom_components/catt/` directory.
- Added a minimal `custom_components/catt/__init__.py` to allow Home Assistant to recognize the integration and HACS to manage it.
- Added `custom_components/catt/manifest.json` with metadata including domain, name, documentation, issue tracker, codeowners, version, iot_class, and pypi requirements for catt.

These changes allow you to add 'catt' as a custom repository in HACS without altering the primary location of the 'catt' source code.