### PR TITLE
Tell apart live videos from buffered videos

### DIFF
--- a/catt/cli.py
+++ b/catt/cli.py
@@ -219,7 +219,11 @@ def cli(ctx, device):
     "Only useful when casting remote files, as catt is already running a server when casting local files. "
     "Currently exits after playback of single media, so not useful with playlists yet.",
 )
-@click.option("--stream-type", type=STREAM_TYPE, help="Treat as a live stream or fixed-length video (for debugging).")
+@click.option(
+    "--stream-type",
+    type=STREAM_TYPE,
+    help="Treat as a live stream or fixed-length video (for debugging).",
+)
 @click.pass_obj
 def cast(
     settings,

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -75,6 +75,8 @@ class YtdlOptParamType(click.ParamType):
 
 YTDL_OPT = YtdlOptParamType()
 
+STREAM_TYPE = click.Choice(["NONE", "BUFFERED", "LIVE"], case_sensitive=False)
+
 
 def process_url(ctx, param, value: str):
     if value == "-":
@@ -217,6 +219,7 @@ def cli(ctx, device):
     "Only useful when casting remote files, as catt is already running a server when casting local files. "
     "Currently exits after playback of single media, so not useful with playlists yet.",
 )
+@click.option("--stream-type", type=STREAM_TYPE, help="Treat as a live stream or fixed-length video (for debugging).")
 @click.pass_obj
 def cast(
     settings,
@@ -228,6 +231,7 @@ def cast(
     no_playlist: bool,
     ytdl_option,
     seek_to: str,
+    stream_type: str,
     block: bool = False,
 ):
     controller = "default" if force_default or ytdl_option else None
@@ -239,6 +243,7 @@ def cast(
         prep="app",
         controller=controller,
         ytdl_options=ytdl_option,
+        stream_type=stream_type,
     )
     media_is_image = stream.guessed_content_category == "image"
     local_or_remote = "local" if stream.is_local_file else "remote"
@@ -300,6 +305,7 @@ def cast(
                 subtitles=subs.url if subs else None,
                 thumb=stream.video_thumbnail,
                 current_time=seek_to,
+                stream_type=stream.stream_type,
             )
         elif cst.info_type == "id":
             cst.play_media_id(stream.video_id, current_time=seek_to)

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -107,7 +107,7 @@ def setup_cast(
     cast_type = cast.cast_type
     app_id = cast.app_id
     stream = (
-        StreamInfo(video_url, cast_info=cast.cast_info, ytdl_options=ytdl_options)
+        StreamInfo(video_url, cast_info=cast.cast_info, ytdl_options=ytdl_options, stream_type=stream_type)
         if video_url
         else None
     )
@@ -545,6 +545,7 @@ class DefaultCastController(CastController, MediaControllerMixin, PlaybackBaseMi
             title=kwargs.get("title"),
             thumb=kwargs.get("thumb"),
             subtitles=kwargs.get("subtitles"),
+            stream_type=kwargs.get("stream_type"),
         )
         self._controller.block_until_active()
 

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -102,12 +102,18 @@ def setup_cast(
     ytdl_options=None,
     action=None,
     prep=None,
+    stream_type=None,
 ):
     cast = get_cast(device_desc)
     cast_type = cast.cast_type
     app_id = cast.app_id
     stream = (
-        StreamInfo(video_url, cast_info=cast.cast_info, ytdl_options=ytdl_options, stream_type=stream_type)
+        StreamInfo(
+            video_url,
+            cast_info=cast.cast_info,
+            ytdl_options=ytdl_options,
+            stream_type=stream_type,
+        )
         if video_url
         else None
     )

--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -51,6 +51,11 @@ class StreamInfo:
             if self._preinfo.get("ie_key"):
                 self._preinfo = self._get_stream_preinfo(self._preinfo["url"])
             self.is_local_file = False
+            if self.stream_type is None and "duration" in self._preinfo:
+                if self._preinfo["duration"] is None:
+                    self.stream_type = "LIVE"
+                else:
+                    self.stream_type = "BUFFERED"
 
             model = (
                 (cast_info.manufacturer, cast_info.model_name) if cast_info else None

--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -35,9 +35,10 @@ DEFAULT_YTDL_OPTS = {"quiet": True, "no_warnings": True}
 
 class StreamInfo:
     def __init__(
-        self, video_url, cast_info=None, ytdl_options=None, throw_ytdl_dl_errs=False
+        self, video_url, cast_info=None, ytdl_options=None, throw_ytdl_dl_errs=False, stream_type=None
     ):
         self._throw_ytdl_dl_errs = throw_ytdl_dl_errs
+        self.stream_type = stream_type
         self.local_ip = get_local_ip(cast_info.host) if cast_info else None
         self.port = random.randrange(45000, 47000) if cast_info else None
 

--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -35,7 +35,12 @@ DEFAULT_YTDL_OPTS = {"quiet": True, "no_warnings": True}
 
 class StreamInfo:
     def __init__(
-        self, video_url, cast_info=None, ytdl_options=None, throw_ytdl_dl_errs=False, stream_type=None
+        self,
+        video_url,
+        cast_info=None,
+        ytdl_options=None,
+        throw_ytdl_dl_errs=False,
+        stream_type=None,
     ):
         self._throw_ytdl_dl_errs = throw_ytdl_dl_errs
         self.stream_type = stream_type


### PR DESCRIPTION
Hello and thank you for this Python library! This is my first PR in this repo.

I started hacking away in order to fix what appeared to be a bug on my end: every time I tried to cast a video from YouTube using the default video application (not the YouTube app, in order to skip ads), it was detected as a live stream. Because of this, CATT wouldn't allow me to save the state of the video, or skip backward and forward. Because of this, I didn't create an issue in GitHub to ask for an opinion.

I don't remember this happening from the start, and it might simply be a weird default at PyChromecast. Anyways, CATT should have an extra function now.

I couldn't get CATT to work with an actual YouTube video live stream (even after discarding all my changes), so I tested it with using regular YouTube videos and a public Spanish TV stream (from a channel named simply "La 1"), using all values of the flag I created, and with no flag (to auto-detect the value).

Please let me know if this is okay, or if you want me to change something on my end. The flag right now makes the list of options uglier and you might prefer me to change its name or get rid of it (there isn't much use for it if auto-detection works correctly).

EDIT: Disclaimer about contribution guidelines
=======

I tried to follow the directions on the Contributing section on the main `README.md`, but only noticed while creating this PR that the bottom of the page says:

> Remember, contributions to this repository should follow its [contributing guidelines](https://github.com/skorokithakis/catt/blob/4660f0423192497ce0a64424e23321d79c4ab7e1/CONTRIBUTING.md).

which points to a different, older file called `CONTRIBUTING.md`. I guess this is deprecated? Some of the stuff you request in there is performed by Git hooks now.

I didn't run automated tests or changed documentation myself. If you want me to do either of those, please let me know.