### PR TITLE
Various changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.12.9
+  rev: v0.14.2
   hooks:
     - id: ruff
       args: [ --fix ]
     - id: ruff-format
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.17.1
+  rev: v1.18.2
   hooks:
   - id: mypy
     name: Run MyPy typing checks.

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -32,6 +32,7 @@ from .util import echo_status
 from .util import echo_warning
 from .util import hunt_subtitles
 from .util import is_ipaddress
+from .util import set_verbosity
 
 CONFIG_DIR = Path(click.get_app_dir("catt"))
 CONFIG_PATH = Path(CONFIG_DIR, "catt.cfg")
@@ -44,6 +45,8 @@ try:
     VERSION = version(PROGRAM_NAME)
 except Exception:
     VERSION = "0.0.0u"
+
+MAX_VERBOSITY = 4
 
 
 class CattTimeParamType(click.ParamType):
@@ -151,18 +154,31 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 @click.group(context_settings=CONTEXT_SETTINGS)
 @click.option("-d", "--device", metavar="NAME_OR_IP", help="Select Chromecast device.")
+@click.option(
+    "-v",
+    "--verbose",
+    count=True,
+    help="Outputs extra information (for debugging; may stack, up to -"
+    + ("v" * MAX_VERBOSITY)
+    + ")",
+)
 @click.version_option(
     version=VERSION,
     prog_name=PROGRAM_NAME,
     message="%(prog)s v%(version)s, " + __codename__ + ".",
 )
 @click.pass_context
-def cli(ctx, device):
+def cli(ctx, device, verbose):
     device_from_config = ctx.obj["options"].get("device")
     ctx.obj["selected_device"] = process_device(
         device or device_from_config, ctx.obj["aliases"]
     )
     ctx.obj["selected_device_is_from_cli"] = bool(device)
+    if verbose > MAX_VERBOSITY:
+        print("Add the flag -{} for maximum verbosity.".format("v" * MAX_VERBOSITY))
+        verbose = MAX_VERBOSITY
+    ctx.obj["verbosity"] = verbose
+    set_verbosity(verbose)
 
 
 @cli.command(short_help="Send a video to a Chromecast for playing.")
@@ -305,16 +321,16 @@ def cast(
             )
         )
         if cst.info_type == "url":
-            cst.play_media_url(
-                stream.video_url,
-                title=stream.video_title,
-                content_type=stream.guessed_content_type,
-                subtitles=subs.url if subs else None,
-                thumb=stream.video_thumbnail,
-                current_time=seek_to,
-                stream_type=stream.stream_type,
-                media_info=stream.media_info,
-            )
+            kwargs = {
+                "title": stream.video_title,
+                "content_type": stream.guessed_content_type,
+                "subtitles": subs.url if subs else None,
+                "thumb": stream.video_thumbnail,
+                "current_time": seek_to,
+                "stream_type": stream.stream_type,
+                "media_info": stream.media_info,
+            }
+            cst.play_media_url(stream.video_url, **kwargs)
         elif cst.info_type == "id":
             cst.play_media_id(stream.video_id, current_time=seek_to)
         else:

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -359,16 +359,20 @@ def subs(settings, track_id, off, list_subs):
     if off:
         cst = setup_cast(settings, action="disable_subtitle", prep="control")
         cst.disable_subtitle()
-    if list_subs:
-        cst = setup_cast(settings, prep="info")
-        for track in cst.info["subtitle_tracks"]:
-            if track.get("type") == "TEXT":
-                trackId = track["trackId"]
-                name = track["name"]
-                click.echo(f"{trackId}\t{name}")
     if track_id:
         cst = setup_cast(settings, action="enable_subtitle", prep="control")
         cst.enable_subtitle(track_id)
+    if list_subs:
+        cst = setup_cast(settings, prep="info")
+        current_subtitle_tracks = cst.info["current_subtitle_tracks"]
+        for track in cst.info["subtitle_tracks"]:
+            trackId = track["trackId"]
+            name = track.get("name")
+            type = track.get("type")
+            language = track.get("language")
+            current_subtitle_tracks = cst.info["current_subtitle_tracks"]
+            enabled = "✓" if trackId in current_subtitle_tracks else " "
+            click.echo(f"{enabled}\t{trackId} [{type}]\t[{language}] {name}")
 
 
 @cli.command("cast_site", short_help="Cast any website to a Chromecast.")

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -580,7 +580,7 @@ def scan(json_output):
     devices = get_cast_infos()
 
     if json_output:
-        echo_json({d.friendly_name: d._asdict() for d in devices})
+        echo_json({d.friendly_name: d.__dict__ for d in devices})
     else:
         if not devices:
             raise CastError("No devices found")

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -245,7 +245,7 @@ def cast(
     playlist_playback = False
     st_thr = su_thr = subs = None
     cst, stream = setup_cast(
-        settings["selected_device"],
+        settings,
         video_url=video_url,
         prep="app",
         controller=controller,
@@ -341,21 +341,17 @@ def subs(settings, track_id, off, list_subs):
         click.echo("Try 'catt subs --help' for help.")
         return
     if off:
-        cst = setup_cast(
-            settings["selected_device"], action="disable_subtitle", prep="control"
-        )
+        cst = setup_cast(settings, action="disable_subtitle", prep="control")
         cst.disable_subtitle()
     if list_subs:
-        cst = setup_cast(settings["selected_device"], prep="info")
+        cst = setup_cast(settings, prep="info")
         for track in cst.info["subtitle_tracks"]:
             if track.get("type") == "TEXT":
                 trackId = track["trackId"]
                 name = track["name"]
                 click.echo(f"{trackId}\t{name}")
     if track_id:
-        cst = setup_cast(
-            settings["selected_device"], action="enable_subtitle", prep="control"
-        )
+        cst = setup_cast(settings, action="enable_subtitle", prep="control")
         cst.enable_subtitle(track_id)
 
 
@@ -364,7 +360,7 @@ def subs(settings, track_id, off, list_subs):
 @click.pass_obj
 def cast_site(settings, url):
     cst = setup_cast(
-        settings["selected_device"],
+        settings,
         controller="dashcast",
         action="load_url",
         prep="app",
@@ -384,7 +380,7 @@ def cast_site(settings, url):
 @click.pass_obj
 def add(settings, video_url, play_next):
     cst, stream = setup_cast(
-        settings["selected_device"], video_url=video_url, action="add", prep="control"
+        settings, video_url=video_url, action="add", prep="control"
     )
     if cst.name != stream.extractor or not (
         stream.is_remote_file or stream.is_playlist_with_active_entry
@@ -402,7 +398,7 @@ def add(settings, video_url, play_next):
 @click.pass_obj
 def remove(settings, video_url):
     cst, stream = setup_cast(
-        settings["selected_device"],
+        settings,
         video_url=video_url,
         action="remove",
         prep="control",
@@ -416,28 +412,28 @@ def remove(settings, video_url):
 @cli.command(short_help="Clear the queue (YouTube only).")
 @click.pass_obj
 def clear(settings):
-    cst = setup_cast(settings["selected_device"], action="clear", prep="control")
+    cst = setup_cast(settings, action="clear", prep="control")
     cst.clear()
 
 
 @cli.command(short_help="Pause a video.")
 @click.pass_obj
 def pause(settings):
-    cst = setup_cast(settings["selected_device"], action="pause", prep="control")
+    cst = setup_cast(settings, action="pause", prep="control")
     cst.pause()
 
 
 @cli.command(short_help="Resume a video after it has been paused.")
 @click.pass_obj
 def play(settings):
-    cst = setup_cast(settings["selected_device"], action="play", prep="control")
+    cst = setup_cast(settings, action="play", prep="control")
     cst.play()
 
 
 @cli.command("play_toggle", short_help="Toggle between playing and paused state.")
 @click.pass_obj
 def play_toggle(settings):
-    cst = setup_cast(settings["selected_device"], action="play_toggle", prep="control")
+    cst = setup_cast(settings, action="play_toggle", prep="control")
     cst.play_toggle()
 
 
@@ -451,7 +447,7 @@ def play_toggle(settings):
 )
 @click.pass_obj
 def stop(settings, force):
-    cst = setup_cast(settings["selected_device"])
+    cst = setup_cast(settings)
     cst.kill(force=force)
 
 
@@ -461,7 +457,7 @@ def stop(settings, force):
 )
 @click.pass_obj
 def rewind(settings, timedesc):
-    cst = setup_cast(settings["selected_device"], action="rewind", prep="control")
+    cst = setup_cast(settings, action="rewind", prep="control")
     cst.rewind(timedesc)
 
 
@@ -471,7 +467,7 @@ def rewind(settings, timedesc):
 )
 @click.pass_obj
 def ffwd(settings, timedesc):
-    cst = setup_cast(settings["selected_device"], action="ffwd", prep="control")
+    cst = setup_cast(settings, action="ffwd", prep="control")
     cst.ffwd(timedesc)
 
 
@@ -479,14 +475,14 @@ def ffwd(settings, timedesc):
 @click.argument("timedesc", type=CATT_TIME, metavar="TIME")
 @click.pass_obj
 def seek(settings, timedesc):
-    cst = setup_cast(settings["selected_device"], action="seek", prep="control")
+    cst = setup_cast(settings, action="seek", prep="control")
     cst.seek(timedesc)
 
 
 @cli.command(short_help="Skip to end of content.")
 @click.pass_obj
 def skip(settings):
-    cst = setup_cast(settings["selected_device"], action="skip", prep="control")
+    cst = setup_cast(settings, action="skip", prep="control")
     cst.skip()
 
 
@@ -494,7 +490,7 @@ def skip(settings):
 @click.argument("level", type=click.IntRange(0, 100), metavar="LVL")
 @click.pass_obj
 def volume(settings, level):
-    cst = setup_cast(settings["selected_device"])
+    cst = setup_cast(settings)
     cst.volume(level / 100.0)
 
 
@@ -504,7 +500,7 @@ def volume(settings, level):
 )
 @click.pass_obj
 def volumeup(settings, delta):
-    cst = setup_cast(settings["selected_device"])
+    cst = setup_cast(settings)
     cst.volumeup(delta / 100.0)
 
 
@@ -514,7 +510,7 @@ def volumeup(settings, delta):
 )
 @click.pass_obj
 def volumedown(settings, delta):
-    cst = setup_cast(settings["selected_device"])
+    cst = setup_cast(settings)
     cst.volumedown(delta / 100.0)
 
 
@@ -522,14 +518,14 @@ def volumedown(settings, delta):
 @click.argument("muted", type=click.BOOL, required=False, default=True, metavar="MUTED")
 @click.pass_obj
 def volumemute(settings, muted):
-    cst = setup_cast(settings["selected_device"])
+    cst = setup_cast(settings)
     cst.volumemute(muted)
 
 
 @cli.command(short_help="Show some information about the currently-playing video.")
 @click.pass_obj
 def status(settings):
-    cst = setup_cast(settings["selected_device"], prep="info")
+    cst = setup_cast(settings, prep="info")
     echo_status(cst.cast_info)
 
 
@@ -538,7 +534,7 @@ def status(settings):
 @click.pass_obj
 def info(settings, json_output):
     try:
-        cst = setup_cast(settings["selected_device"], prep="info")
+        cst = setup_cast(settings, prep="info")
     except CastError:
         if json_output:
             info = {}
@@ -580,7 +576,7 @@ def scan(json_output):
 )
 @click.pass_obj
 def save(settings, path):
-    cst = setup_cast(settings["selected_device"], prep="control")
+    cst = setup_cast(settings, prep="control")
     if not cst.save_capability or cst.is_streaming_local_file:
         raise CliError("Saving state of this kind of content is not supported")
     elif cst.save_capability == "partial":
@@ -607,7 +603,7 @@ def save(settings, path):
 def restore(settings, path):
     if not path and not STATE_PATH.is_file():
         raise CliError("Save file in config dir has not been created")
-    cst = setup_cast(settings["selected_device"])
+    cst = setup_cast(settings)
     state = CastState(path or STATE_PATH, StateMode.READ)
     try:
         data = state.get_data(cst.cc_name if not path else None)
@@ -618,9 +614,7 @@ def restore(settings, path):
 
     echo_status(data["data"])
     click.echo("Restoring...")
-    cst = setup_cast(
-        settings["selected_device"], prep="app", controller=data["controller"]
-    )
+    cst = setup_cast(settings, prep="app", controller=data["controller"])
     cst.restore(data["data"])
 
 

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -22,7 +22,11 @@ from .error import ControllerError
 from .error import ListenerError
 from .error import StateFileError
 from .stream_info import StreamInfo
+from .util import echo_debug
 from .util import echo_warning
+from .util import echo_verbose
+
+global verbosity
 
 GOOGLE_MEDIA_NAMESPACE = "urn:x-cast:com.google.cast.media"
 VALID_STATE_EVENTS = ["UNKNOWN", "IDLE", "BUFFERING", "PLAYING", "PAUSED"]
@@ -104,9 +108,11 @@ def setup_cast(
     prep=None,
     stream_type=None,
 ):
+    echo_verbose("Setting up casting")
     cast = get_cast(settings["selected_device"])
     settings["cast_info"] = cast.cast_info
     cast_type = cast.cast_type
+    echo_debug(cast)
     app_id = cast.app_id
     stream = (
         StreamInfo(
@@ -133,7 +139,10 @@ def setup_cast(
     else:
         app = get_app("default")
 
+    echo_verbose(f"App: {app}")
+
     cast_controller = get_controller(cast, app, action=action, prep=prep)
+    echo_debug(f"Cast controller: {cast_controller}")
     return (cast_controller, stream) if stream else cast_controller
 
 

--- a/catt/controllers.py
+++ b/catt/controllers.py
@@ -96,7 +96,7 @@ def get_controller(cast, app, action=None, prep=None) -> "CastController":
 
 
 def setup_cast(
-    device_desc,
+    settings,
     video_url=None,
     controller=None,
     ytdl_options=None,
@@ -104,13 +104,14 @@ def setup_cast(
     prep=None,
     stream_type=None,
 ):
-    cast = get_cast(device_desc)
+    cast = get_cast(settings["selected_device"])
+    settings["cast_info"] = cast.cast_info
     cast_type = cast.cast_type
     app_id = cast.app_id
     stream = (
         StreamInfo(
             video_url,
-            cast_info=cast.cast_info,
+            settings,
             ytdl_options=ytdl_options,
             stream_type=stream_type,
         )

--- a/catt/http_server.py
+++ b/catt/http_server.py
@@ -74,6 +74,7 @@ def serve_file(
             return super(FileHandler, self).log_message(format, *args, **kwargs)
 
         def do_GET(self):  # noqa
+            mediafile = None
             if "Range" not in self.headers:
                 first, last = 0, stats.st_size
             else:
@@ -98,7 +99,7 @@ def serve_file(
                     )
 
                 self.send_header("Accept-Ranges", "bytes")
-                self.send_header("Content-type", content_type)
+                self.send_header("Content-Type", content_type)
                 self.send_header("Content-Length", str(response_length))
                 self.send_header("Access-Control-Allow-Origin", "*")
                 self.send_header(
@@ -121,8 +122,9 @@ def serve_file(
                 )
             except:  # noqa
                 traceback.print_exc()
-
-            mediafile.close()
+            finally:
+                if mediafile:
+                    mediafile.close()
 
     if content_type is None:
         content_type = guess_mime(filename)

--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -8,6 +8,9 @@ from .error import FormatError
 from .error import PlaylistError
 from .util import get_local_ip
 from .util import guess_mime
+from .util import echo_debug
+from .util import echo_trace
+from .util import echo_verbose
 
 AUDIO_DEVICE_TYPES = ["audio", "group"]
 # The manufacturer field is currently unavailable for Google products.
@@ -30,7 +33,14 @@ AUDIO_FORMAT = (
 ULTRA_FORMAT = BEST_MAX_4K + BANDCAMP_NO_AIFF_ALAC
 STANDARD_FORMAT = BEST_MAX_2K + MAX_50FPS + TWITCH_NO_60FPS + BANDCAMP_NO_AIFF_ALAC
 
-DEFAULT_YTDL_OPTS = {"quiet": True, "no_warnings": True}
+# DEFAULT_YTDL_OPTS depends on verbosity:
+DEFAULT_YTDL_OPTS = {
+    0: {"quiet": True, "no_warnings": True},
+    1: {"quiet": True},
+    2: {},
+    3: {"verbose": True},
+    4: {"verbose": True, "print_traffic": True},
+}
 
 SUBTITLE_PRIORITY = {"vtt": 30, "ttml": 20, "srt": 10}
 
@@ -45,6 +55,7 @@ class StreamInfo:
         stream_type=None,
     ):
         cast_info = settings.get("cast_info")
+        verbosity = settings.get("verbosity", 0)
         self._throw_ytdl_dl_errs = throw_ytdl_dl_errs
         self.stream_type = stream_type
         self.local_ip = get_local_ip(cast_info.host) if cast_info else None
@@ -53,11 +64,12 @@ class StreamInfo:
 
         if "://" in video_url:
             self._ydl = yt_dlp.YoutubeDL(
-                dict(ytdl_options) if ytdl_options else DEFAULT_YTDL_OPTS
+                dict(ytdl_options) or DEFAULT_YTDL_OPTS[verbosity]
             )
             self._preinfo = self._get_stream_preinfo(video_url)
             # Some playlist urls needs to be re-processed (such as youtube channel urls).
             if self._preinfo.get("ie_key"):
+                echo_verbose("Got playlist, reprocessing")
                 self._preinfo = self._get_stream_preinfo(self._preinfo["url"])
             self.is_local_file = False
             if self.stream_type is None and "duration" in self._preinfo:
@@ -65,6 +77,11 @@ class StreamInfo:
                     self.stream_type = "LIVE"
                 else:
                     self.stream_type = "BUFFERED"
+                echo_verbose("Autoselected stream_type {}".format(self.stream_type))
+            else:
+                echo_verbose(
+                    "Manually selected stream_type {}".format(self.stream_type)
+                )
             subs = self._preinfo.get("subtitles")
             if subs:
                 self.media_info = {"tracks": []}
@@ -80,6 +97,7 @@ class StreamInfo:
                         formats,
                         key=lambda f: SUBTITLE_PRIORITY.get(f.get("ext", "vtt"), 0),
                     )
+                    echo_debug(f"Found potential subtitles: {best}")
                     best.setdefault("ext", "vtt")
                     # Add a blank name if there is none:
                     best.setdefault("name", "")
@@ -99,6 +117,15 @@ class StreamInfo:
                                 "name": f"[{lang}] " + best["name"],
                             }
                         )
+                        echo_debug(
+                            'Adding subtitle "{}" in {} language and {} format'.format(
+                                best["name"],
+                                lang,
+                                best["ext"],
+                            ),
+                        )
+                    else:
+                        echo_debug("Discarding subtitle")
 
             model = (
                 (cast_info.manufacturer, cast_info.model_name) if cast_info else None
@@ -109,13 +136,18 @@ class StreamInfo:
                 # if it holds an invalid value.
                 self._best_format = self._ydl.params.pop("format")
             elif cast_type and cast_type in AUDIO_DEVICE_TYPES:
+                echo_verbose("Casting audio")
                 self._best_format = AUDIO_FORMAT
             elif model and model in ULTRA_MODELS:
+                echo_verbose("Not casting audio. Ultra model")
                 self._best_format = ULTRA_FORMAT
             else:
+                echo_verbose("Not casting audio. Not an ultra model")
                 self._best_format = STANDARD_FORMAT
+            echo_verbose('Format selector: "{}"'.format(self._best_format))
 
             if self.is_playlist:
+                echo_verbose("Playlist detected")
                 self._entries = list(self._preinfo["entries"])
                 # There appears to be no way to extract both a YouTube video id,
                 # and ditto playlist id in one go (in the case of an url containing both),
@@ -128,10 +160,12 @@ class StreamInfo:
                     else None
                 )
             else:
+                echo_verbose("Target is not playlist")
                 self._info = self._get_stream_info(self._preinfo)
         else:
             self._local_file = video_url
             self.is_local_file = True
+        echo_verbose("guessed_content_type set to {}".format(self.guessed_content_type))
 
     @property
     def is_remote_file(self):
@@ -237,7 +271,10 @@ class StreamInfo:
 
     def _get_stream_preinfo(self, video_url):
         try:
-            return self._ydl.extract_info(video_url, process=False)
+            data = self._ydl.extract_info(video_url, process=False)
+            echo_verbose("Running yt_dlp.extract_info()")
+            echo_trace(data)
+            return data
         except yt_dlp.utils.DownloadError:
             # We sometimes get CI failures when testing with YouTube videos,
             # as YouTube throttles our connections intermittently. We evaluated
@@ -258,6 +295,7 @@ class StreamInfo:
             raise ExtractionError("yt-dlp extractor failed")
 
     def _get_stream_url(self, info):
+        echo_debug("Entering _get_stream_url()")
         try:
             format_selector = self._ydl.build_format_selector(self._best_format)
         except ValueError:
@@ -272,4 +310,5 @@ class StreamInfo:
         except KeyError:
             best_format = info
 
+        echo_debug(f'best_format = "{best_format}"')
         return best_format["url"]

--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -20,7 +20,7 @@ AUDIO_DEVICE_TYPES = ["audio", "group"]
 # See https://github.com/balloob/pychromecast/pull/197
 ULTRA_MODELS = [("Xiaomi", "MIBOX3"), ("Unknown manufacturer", "Chromecast Ultra")]
 
-BEST_MAX_2K = "best[width <=? 1920][height <=? 1080]"
+BEST_MAX_2K = "best[width <=? 1920][height <=? 1080][vcodec!^=av1][vcodec!^=av01][vcodec!^=vp9][vcodec!^=h265]"
 BEST_MAX_4K = "best[width <=? 3840][height <=? 2160]"
 BEST_ONLY_AUDIO = "bestaudio"
 BEST_FALLBACK = "/best"
@@ -61,7 +61,7 @@ class StreamInfo:
         self.stream_type = stream_type
         self.local_ip = get_local_ip(cast_info.host) if cast_info else None
         self.port = random.randrange(45000, 47000) if cast_info else None
-        self.media_info = None
+        self.media_info = {}
         self.guessed_content_type = None
 
         if "://" in video_url:
@@ -86,11 +86,10 @@ class StreamInfo:
                 )
             subs = self._preinfo.get("subtitles")
             if subs:
-                self.media_info = {"tracks": []}
                 # YouTube (and other platforms) serves subtitles for
                 # a single language in multiple formats
                 # This code traverses the raw information from yt-dlp.
-                for i, (lang, formats) in enumerate(subs.items(), 1):
+                for lang, formats in subs.items():
                     # Pick the best format, as decided by SUBTITLE_PRIORITY
                     # Incomptible subtitles have no entry in that dict,
                     # and get zero priority by default.
@@ -113,17 +112,18 @@ class StreamInfo:
                                 best["ext"],
                             ),
                         )
-                        newtrack = {
-                            "trackId": i,
-                            "trackContentId": best["url"],
-                            "language": lang,
-                            "subtype": "SUBTITLES",
-                            "type": "TEXT",
-                            "trackContentType": guess_mime("subtitles." + best["ext"]),
-                            "name": f"[{lang}] " + best["name"],
-                        }
-                        echo_verbose(newtrack)
-                        self.media_info["tracks"].append(newtrack)
+                        self._add_track_to_stream(
+                            {
+                                "trackContentId": best["url"],
+                                "language": lang,
+                                "subtype": "SUBTITLES",
+                                "type": "TEXT",
+                                "trackContentType": guess_mime(
+                                    "subtitles." + best["ext"]
+                                ),
+                                "name": f"[{lang}] " + best["name"],
+                            }
+                        )
                     else:
                         echo_debug("Discarding subtitle")
 
@@ -332,3 +332,13 @@ class StreamInfo:
 
         echo_debug(f'best_format = "{best_format}"')
         return best_format["url"]
+
+    def _add_track_to_stream(self, track):
+        if self.media_info.get("tracks") is None:
+            echo_debug("Initializing list of extra tracks to cast")
+            self.media_info["tracks"] = []
+        if track.get("trackId") is None:
+            track["trackId"] = len(self.media_info["tracks"]) + 1
+        echo_verbose('Adding new track to self.media_info["tracks"]')
+        echo_debug(track)
+        self.media_info["tracks"].append(track)

--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -10,6 +10,7 @@ from .util import get_local_ip
 from .util import guess_mime
 from .util import echo_debug
 from .util import echo_trace
+from .util import echo_warning
 from .util import echo_verbose
 
 AUDIO_DEVICE_TYPES = ["audio", "group"]
@@ -61,6 +62,7 @@ class StreamInfo:
         self.local_ip = get_local_ip(cast_info.host) if cast_info else None
         self.port = random.randrange(45000, 47000) if cast_info else None
         self.media_info = None
+        self.guessed_content_type = None
 
         if "://" in video_url:
             self._ydl = yt_dlp.YoutubeDL(
@@ -104,26 +106,24 @@ class StreamInfo:
                     # Only add the subtitle if compatible
                     # (subtitles with zero priority are discarded)
                     if SUBTITLE_PRIORITY.get(best["ext"], 0) > 0:
-                        self.media_info["tracks"].append(
-                            {
-                                "trackId": i,
-                                "trackContentId": best["url"],
-                                "language": lang,
-                                "subtype": "SUBTITLES",
-                                "type": "TEXT",
-                                "trackContentType": guess_mime(
-                                    "subtitles." + best["ext"]
-                                ),
-                                "name": f"[{lang}] " + best["name"],
-                            }
-                        )
-                        echo_debug(
+                        echo_verbose(
                             'Adding subtitle "{}" in {} language and {} format'.format(
                                 best["name"],
                                 lang,
                                 best["ext"],
                             ),
                         )
+                        newtrack = {
+                            "trackId": i,
+                            "trackContentId": best["url"],
+                            "language": lang,
+                            "subtype": "SUBTITLES",
+                            "type": "TEXT",
+                            "trackContentType": guess_mime("subtitles." + best["ext"]),
+                            "name": f"[{lang}] " + best["name"],
+                        }
+                        echo_verbose(newtrack)
+                        self.media_info["tracks"].append(newtrack)
                     else:
                         echo_debug("Discarding subtitle")
 
@@ -131,10 +131,21 @@ class StreamInfo:
                 (cast_info.manufacturer, cast_info.model_name) if cast_info else None
             )
             cast_type = cast_info.cast_type if cast_info else None
+            # If a `format` was input, CATT will assume it is valid and
+            # compatible with the current ChromeCast, but will ask the user to
+            # manually check if it is the case.
+            # If no `format` was provided, CATT will select a default according
+            # to the ChromeCast.
             if "format" in self._ydl.params:
-                # We pop the "format" item, as it will make get_stream_info fail,
-                # if it holds an invalid value.
-                self._best_format = self._ydl.params.pop("format")
+                echo_warning(
+                    "A format was provided manually. CATT will not check if the format is compatible with your device.\n"
+                    + "To see the list of compatible formats and codecs, please check your device version at:\n"
+                    + "\n"
+                    + "https://developers.google.com/cast/docs/media\n"
+                    + "\n"
+                    + "CATT will select the best format for your specific device if none is provided"
+                )
+                self._best_format = self._ydl.params["format"]
             elif cast_type and cast_type in AUDIO_DEVICE_TYPES:
                 echo_verbose("Casting audio")
                 self._best_format = AUDIO_FORMAT
@@ -162,9 +173,27 @@ class StreamInfo:
             else:
                 echo_verbose("Target is not playlist")
                 self._info = self._get_stream_info(self._preinfo)
+            ext = self._info.get("ext")
+            echo_debug(f"yt-dlp reports extension as {ext}")
+            self.guessed_content_type = guess_mime("a." + ext) if ext else None
         else:
             self._local_file = video_url
             self.is_local_file = True
+            self.guessed_content_type = guess_mime(video_url)
+            if self.stream_type is None:
+                if (self.guessed_content_type.split("/"))[0] == "application":
+                    echo_warning(
+                        "Setting stream type to BUFFERED (not a live stream).\n"
+                        + "\n"
+                        + "This is a safe choice for the vast majority of cases.\n"
+                        + "However, it is not adequate if the file is a streaming manifest pointing to a live stream.\n"
+                        + "If that is the case, please run CATT with the flag `--stream-type BUFFERED`"
+                    )
+                else:
+                    echo_verbose(
+                        "Stream type set automatically to BUFFERED (not a live stream)",
+                    )
+                self.stream_type = "BUFFERED"
         echo_verbose("guessed_content_type set to {}".format(self.guessed_content_type))
 
     @property
@@ -224,15 +253,6 @@ class StreamInfo:
             if self.is_remote_file or self.is_playlist_with_active_entry
             else None
         )
-
-    @property
-    def guessed_content_type(self):
-        if self.is_local_file:
-            return guess_mime(Path(self._local_file).name)
-        elif self._is_direct_link:
-            return guess_mime(self._info["webpage_url_basename"])
-        else:
-            return None
 
     @property
     def guessed_content_category(self):

--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -187,7 +187,7 @@ class StreamInfo:
                         + "\n"
                         + "This is a safe choice for the vast majority of cases.\n"
                         + "However, it is not adequate if the file is a streaming manifest pointing to a live stream.\n"
-                        + "If that is the case, please run CATT with the flag `--stream-type BUFFERED`"
+                        + "If that is the case, please run CATT with the flag `--stream-type live`"
                     )
                 else:
                     echo_verbose(

--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -39,11 +39,12 @@ class StreamInfo:
     def __init__(
         self,
         video_url,
-        cast_info=None,
+        settings={},
         ytdl_options=None,
         throw_ytdl_dl_errs=False,
         stream_type=None,
     ):
+        cast_info = settings.get("cast_info")
         self._throw_ytdl_dl_errs = throw_ytdl_dl_errs
         self.stream_type = stream_type
         self.local_ip = get_local_ip(cast_info.host) if cast_info else None

--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -20,14 +20,14 @@ AUDIO_DEVICE_TYPES = ["audio", "group"]
 # See https://github.com/balloob/pychromecast/pull/197
 ULTRA_MODELS = [("Xiaomi", "MIBOX3"), ("Unknown manufacturer", "Chromecast Ultra")]
 
-BEST_MAX_2K = "best[width <=? 1920][height <=? 1080][vcodec!^=av1][vcodec!^=av01][vcodec!^=vp9][vcodec!^=h265]"
+BEST_MAX_2K = "best[width <=? 1920][height <=? 1080][vcodec!^=?av1][vcodec!^=?av01][vcodec!^=?vp9][vcodec!^=?h265]"
 BEST_MAX_4K = "best[width <=? 3840][height <=? 2160]"
 BEST_ONLY_AUDIO = "bestaudio"
 BEST_FALLBACK = "/best"
 MAX_50FPS = "[fps <=? 50]"
-TWITCH_NO_60FPS = "[format_id != 1080p60__source_][format_id != 720p60]"
-MIXCLOUD_NO_DASH_HLS = "[format_id != dash-a1-x3][format_id !*= hls-6]"
-BANDCAMP_NO_AIFF_ALAC = "[format_id != aiff-lossless][format_id != alac]"
+TWITCH_NO_60FPS = "[format_id !=? 1080p60__source_][format_id !=? 720p60]"
+MIXCLOUD_NO_DASH_HLS = "[format_id !=? dash-a1-x3][format_id !*=? hls-6]"
+BANDCAMP_NO_AIFF_ALAC = "[format_id !=? aiff-lossless][format_id !=? alac]"
 AUDIO_FORMAT = (
     BEST_ONLY_AUDIO + MIXCLOUD_NO_DASH_HLS + BANDCAMP_NO_AIFF_ALAC + BEST_FALLBACK
 )

--- a/catt/util.py
+++ b/catt/util.py
@@ -8,10 +8,39 @@ from pathlib import Path
 import click
 import ifaddr
 
+global verbosity
+verbosity: int = 0
+
+
+def set_verbosity(_: int):
+    global verbosity
+    verbosity = _
+
+
+def _echo(msg: str, prefix: str, color: str, display):
+    if display:
+        click.secho(prefix, fg=color, nl=False, err=True)
+        click.echo("{}.".format(msg), err=True)
+
 
 def echo_warning(msg):
-    click.secho("Warning: ", fg="red", nl=False, err=True)
-    click.echo("{}.".format(msg), err=True)
+    _echo(msg, "Warning: ", "yellow", True)
+
+
+def echo_info(msg):
+    _echo(msg, "", "white", verbosity >= 1)
+
+
+def echo_verbose(msg):
+    _echo(msg, "[CATT verbose] ", "magenta", verbosity >= 2)
+
+
+def echo_debug(msg):
+    _echo(msg, "[CATT debug] ", "green", verbosity >= 3)
+
+
+def echo_trace(msg):
+    _echo(msg, "[CATT trace] ", "blue", verbosity >= 4)
 
 
 def echo_json(data_dict):

--- a/catt/util.py
+++ b/catt/util.py
@@ -89,6 +89,9 @@ def guess_mime(path):
         ".srt": "application/x-subrip",
         ".ttml": "application/ttml+xml",
         ".vtt": "text/vtt",
+        ".ts": "video/mp2t",
+        ".m3u8": "application/vnd.apple.mpegurl",
+        ".mpd": "application/dash+xml",
     }
     return extensions.get(extension, "video/mp4")
 


### PR DESCRIPTION
Each commit includes a changelog.

I've been working on this code for days on my computer. None of the commits should be broken (the script should work normally no matter which commit do you pick) but I had to edit my commits several times. In particular, my original debugging functions were a nightmare to set up, and replacing them force me to amend all the following commits.

My original intention was to unblock YouTube videos again, but so far, I haven't had any luck.

Newish videos on YouTube (from the last two years?) currently can't be downloaded in a merged format. The only options are:
- using an M3U8 manifest to download video and audio segments
- casting a video-only stream
- or casting an audio-only stream.

The first option works out of the box for the Tears of Steel test video at [`lolitemaultes/m3u8-urls`](https://github.com/lolitemaultes/m3u8-urls) and for streams from RTVE (Spanish public TV), but when CATT selects a YouTube M3U8 manifest, it just shows the Cast icon over black background.

I couldn't find any way to root my ChromeCast, or figure out debugging. I tried casting video only then adding audio tracks, but not only does the ChromeCast not add them, it stops responding to CATT commands other than `catt stop`.

Subtitling code should probably go to `subs_info.py`, but right now moving more code around will take me several days and result in no extra functionality.

Any help is welcome.

EDIT:
- The mandatory checks on my computer didn't check for `api.py`... but I just made a tiny change in order not to break the API. (If input `device_desc` to `StreamInfo()` was optional, the dict `settings` replacing it must be optional too).
- Edited the message for one of the first commits because in order to say `Click` instead of @click (I'm sorry if I pinged them for no reason).