### PR TITLE
Title, Volume and remote Mp3 files fix

### DIFF
--- a/catt/cli.py
+++ b/catt/cli.py
@@ -564,7 +564,14 @@ def scan(json_output):
     devices = get_cast_infos()
 
     if json_output:
-        echo_json({d.friendly_name: d._asdict() for d in devices})
+        echo_json({d.friendly_name: {
+            'host': d.host,
+            'port': d.port,
+            'uuid': d.uuid,
+            'model_name': d.model_name,
+             'friendly_name': d.friendly_name,
+             'manufacturer': d.manufacturer
+        } for d in devices})
     else:
         if not devices:
             raise CastError("No devices found")

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -215,6 +215,12 @@ def cli(ctx, device):
     help="Start playback at specific timestamp.",
 )
 @click.option(
+    "-l",
+    "--title",
+    metavar="TITLE",
+    help="Specify a title for the media file.",
+)
+@click.option(
     "-b",
     "--block",
     is_flag=True,
@@ -238,6 +244,7 @@ def cast(
     no_playlist: bool,
     ytdl_option,
     seek_to: str,
+    title: str,
     stream_type: str,
     block: bool = False,
 ):
@@ -300,14 +307,14 @@ def cast(
         click.echo(
             '{} "{}" on "{}"...'.format(
                 "Showing" if media_is_image else "Playing",
-                stream.video_title,
+                title or stream.video_title,
                 cst.cc_name,
             )
         )
         if cst.info_type == "url":
             cst.play_media_url(
                 stream.video_url,
-                title=stream.video_title,
+                title=title or stream.video_title,
                 content_type=stream.guessed_content_type,
                 subtitles=subs.url if subs else None,
                 thumb=stream.video_thumbnail,

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -221,6 +221,13 @@ def cli(ctx, device):
     help="Specify a title for the media file.",
 )
 @click.option(
+    "-v",
+    "--volume",
+    type=click.IntRange(0, 100),
+    metavar="LVL",
+    help="Set volume (0-100).",
+)
+@click.option(
     "-b",
     "--block",
     is_flag=True,
@@ -245,6 +252,7 @@ def cast(
     ytdl_option,
     seek_to: str,
     title: str,
+    volume: int,
     stream_type: str,
     block: bool = False,
 ):
@@ -311,6 +319,9 @@ def cast(
                 cst.cc_name,
             )
         )
+        if volume is not None:
+            cst.volume(volume / 100.0)
+
         if cst.info_type == "url":
             cst.play_media_url(
                 stream.video_url,
@@ -319,8 +330,8 @@ def cast(
                 subtitles=subs.url if subs else None,
                 thumb=stream.video_thumbnail,
                 current_time=seek_to,
-                stream_type=stream.stream_type,
-                media_info=stream.media_info,
+                stream_type=getattr(stream, "stream_type", None),
+                media_info=getattr(stream, "media_info", None),
             )
         elif cst.info_type == "id":
             cst.play_media_id(stream.video_id, current_time=seek_to)

--- a/catt/cli.py
+++ b/catt/cli.py
@@ -582,14 +582,19 @@ def scan(json_output):
     devices = get_cast_infos()
 
     if json_output:
-        echo_json({d.friendly_name: {
-            'host': d.host,
-            'port': d.port,
-            'uuid': d.uuid,
-            'model_name': d.model_name,
-             'friendly_name': d.friendly_name,
-             'manufacturer': d.manufacturer
-        } for d in devices})
+        echo_json(
+            {
+                d.friendly_name: {
+                    "host": d.host,
+                    "port": d.port,
+                    "uuid": d.uuid,
+                    "model_name": d.model_name,
+                    "friendly_name": d.friendly_name,
+                    "manufacturer": d.manufacturer,
+                }
+                for d in devices
+            }
+        )
     else:
         if not devices:
             raise CastError("No devices found")

--- a/catt/stream_info.py
+++ b/catt/stream_info.py
@@ -257,6 +257,9 @@ class StreamInfo:
             raise ExtractionError("yt-dlp extractor failed")
 
     def _get_stream_url(self, info):
+        if info.get("direct"):
+            return info["url"]
+
         try:
             format_selector = self._ydl.build_format_selector(self._best_format)
         except ValueError:

--- a/tests/test_catt.py
+++ b/tests/test_catt.py
@@ -58,6 +58,13 @@ class TestThings(unittest.TestCase):
         self.assertTrue(stream.is_remote_file)
         self.assertEqual(stream.extractor, "twitch")
 
+    def test_stream_info_direct_link(self):
+        url = "https://file-examples.com/storage/fede0b421769af5709b2497/2017/11/file_example_MP3_700KB.mp3"
+        stream = StreamInfo(url)
+        self.assertEqual(stream.video_url, url)
+        self.assertTrue(stream.is_remote_file)
+        self.assertTrue(stream._is_direct_link)
+
 
 if __name__ == "__main__":
     import sys

--- a/tests/test_catt.py
+++ b/tests/test_catt.py
@@ -59,7 +59,7 @@ class TestThings(unittest.TestCase):
         self.assertEqual(stream.extractor, "twitch")
 
     def test_stream_info_direct_link(self):
-        url = "https://file-examples.com/storage/fede0b421769af5709b2497/2017/11/file_example_MP3_700KB.mp3"
+        url = "https://homeazan.com/file_example_MP3_700KB.mp3"
         stream = StreamInfo(url)
         self.assertEqual(stream.video_url, url)
         self.assertTrue(stream.is_remote_file)


### PR DESCRIPTION
Added ability to provide title (useful for the mp3 media player) and volume when casting. 

Also remote mp3 files didnt work before, now they do instead of saying "no suitable format found"


Example:

`catt -d Office cast https://file-examples.com/storage/fede0b421769af5709b2497/2017/11/file_example_MP3_700KB.mp3 --title "This is a title" --volume 20`

oh, also output as json gives more info now